### PR TITLE
Change time correction sign

### DIFF
--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -168,7 +168,7 @@ function calc_pvt(
     )
     relative_clock_drift = user_velocity_and_clock_drift[4] / SPEEDOFLIGHT
     time_correction = ξ[4]
-    corrected_reference_time = reference_time + time_correction / SPEEDOFLIGHT
+    corrected_reference_time = reference_time + time_correction / (-SPEEDOFLIGHT)
 
     week = get_week(first(healthy_states).decoder)
     start_time = get_system_start_time(first(healthy_states).decoder)


### PR DESCRIPTION
Previously calc_pvt applies time correction factor with the wrong sign, which results in correct position solution at wrong time. For more information look at
https://github.com/JuliaGNSS/PositionVelocityTime.jl/issues/8 , and closes that issue
