### PR TITLE
Pass prev_ξ to user_position so prev_pvt warm-starts the LM solve

### DIFF
--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -239,7 +239,7 @@ function calc_pvt(
     )
     sat_positions = map(get_sat_position, sat_positions_and_velocities)
     pseudo_ranges, reference_time = calc_pseudo_ranges(times)
-    ξ, rmse = user_position(sat_positions, pseudo_ranges)
+    ξ, rmse = user_position(sat_positions, pseudo_ranges, prev_ξ)
     user_velocity_and_clock_drift =
         calc_user_velocity_and_clock_drift(sat_positions_and_velocities, ξ, healthy_states)
     position = ECEF(ξ[1], ξ[2], ξ[3])

--- a/test/pvt.jl
+++ b/test/pvt.jl
@@ -496,6 +496,11 @@ BitIntegers.@define_integers 320
     @test pvt.time ≈ TAIEpoch(2021, 5, 31, 12, 53, 14.1183385390904732)
     @test pvt.velocity ≈ ECEF(0.0, 0.0, 0.0) atol = 9
     @test get_frequency_offset(pvt, get_center_frequency(galileo_e1b)) ≈ -(1675.63Hz + freq_offset) atol = 0.01Hz
+
+    warm_pvt = calc_pvt(states, pvt)
+    @test get_LLA(warm_pvt) ≈ get_LLA(pvt)
+    @test warm_pvt.time ≈ pvt.time
+    @test warm_pvt.velocity ≈ pvt.velocity atol = 1e-6
 end
 
 @testset "PVT GPS L1 with frequency offset of $freq_offset" for freq_offset in (0.0Hz, 500Hz, -1000Hz)
@@ -1427,4 +1432,9 @@ end
     @test pvt.time ≈ TAIEpoch(2021, 5, 31, 12, 53, 14.1491024351271335)
     @test pvt.velocity ≈ ECEF(0.0, 0.0, 0.0) atol = 2.5
     @test get_frequency_offset(pvt, get_center_frequency(gpsl1)) ≈ -(1632.59Hz + freq_offset) atol = 0.01Hz
+
+    warm_pvt = calc_pvt(states, pvt)
+    @test get_LLA(warm_pvt) ≈ get_LLA(pvt)
+    @test warm_pvt.time ≈ pvt.time
+    @test warm_pvt.velocity ≈ pvt.velocity atol = 1e-6
 end


### PR DESCRIPTION
## Summary
- `calc_pvt` built `prev_ξ` from `prev_pvt` but called `user_position(sat_positions, pseudo_ranges)` without it, so Levenberg–Marquardt always started from `zeros(4)`. The `prev_pvt` argument was effectively a runtime no-op.
- One-line fix: thread `prev_ξ` through to `user_position`.

## Local benchmark (master vs branch, BenchmarkTools minimum, samples=200)
| Suite | master cold | master warm | branch cold | branch warm | warm speedup |
|---|---|---|---|---|---|
| GPSL1 9sats | 68.13 µs | 67.91 µs | 67.89 µs | 39.20 µs | **1.73×** |
| GPSL1 4sats | 50.82 µs | 51.14 µs | 41.34 µs | 46.10 µs | 0.90× ⚠️ |
| GalileoE1B 5sats | 46.00 µs | 51.08 µs | 43.54 µs | 28.06 µs | **1.55×** |
| GalileoE1B 4sats | 49.69 µs | 46.34 µs | 38.67 µs | 24.82 µs | **1.56×** |

The GPSL1 4-sat case looks like noise — at minimum geometry the prior helps less, and 4 µs is well within run-to-run variance. AirspeedVelocity's median-based comparison on this PR will be the authoritative read.

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — all existing PVT tests pass (4 sats × 3 frequency offsets × 2 systems).
- [ ] AirspeedVelocity workflow comparison on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)