### PR TITLE
Reduce calc_pvt allocations and runtime by ~50%

### DIFF
--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -240,8 +240,10 @@ function calc_pvt(
     sat_positions = map(get_sat_position, sat_positions_and_velocities)
     pseudo_ranges, reference_time = calc_pseudo_ranges(times)
     ξ, rmse = user_position(sat_positions, pseudo_ranges, prev_ξ)
-    user_velocity_and_clock_drift =
-        calc_user_velocity_and_clock_drift(sat_positions_and_velocities, ξ, healthy_states)
+    sat_positions_mat = reduce(hcat, sat_positions)
+    H = calc_H(sat_positions_mat, ξ)
+    user_velocity_and_clock_drift = calc_user_velocity_and_clock_drift(
+        sat_positions_and_velocities, ξ, healthy_states, H)
     position = ECEF(ξ[1], ξ[2], ξ[3])
     velocity = ECEF(
         user_velocity_and_clock_drift[1],
@@ -263,7 +265,7 @@ function calc_pvt(
 
     sat_infos = SatInfo.(sat_positions, times)
 
-    dop = calc_DOP(calc_H(reduce(hcat, sat_positions), ξ))
+    dop = calc_DOP(H)
     if dop.GDOP < 0
         return prev_pvt
     end

--- a/src/user_position.jl
+++ b/src/user_position.jl
@@ -7,14 +7,17 @@ $SIGNATURES
 `sat_positions`: Satellite Positions
 """
 function calc_ρ_hat(sat_positions, ξ)
-    rₙ = ξ[1:3]
+    rₙ = SVector{3}(ξ[1], ξ[2], ξ[3])
     tc = ξ[4]
-
-    map(eachcol(sat_positions)) do sat_pos
+    n = size(sat_positions, 2)
+    ρ = Vector{Float64}(undef, n)
+    for j in 1:n
+        sat_pos = SVector{3}(sat_positions[1, j], sat_positions[2, j], sat_positions[3, j])
         travel_time = norm(sat_pos - rₙ) / SPEEDOFLIGHT
         rotated_sat_pos = rotate_by_earth_rotation(sat_pos, travel_time)
-        norm(rotated_sat_pos - rₙ) + tc
+        ρ[j] = norm(rotated_sat_pos - rₙ) + tc
     end
+    return ρ
 end
 
 function rotate_by_earth_rotation(sat_pos, Δt)
@@ -36,7 +39,7 @@ $SIGNATURES
 `sat_pos`: Single satellite positions
 """
 function calc_e(sat_pos, ξ)
-    rₙ = ξ[1:3]
+    rₙ = SVector{3}(ξ[1], ξ[2], ξ[3])
     travel_time = norm(sat_pos - rₙ) / SPEEDOFLIGHT
     rotated_sat_pos = rotate_by_earth_rotation(sat_pos, travel_time)
     (rₙ - rotated_sat_pos) / norm(rₙ - rotated_sat_pos)
@@ -51,7 +54,17 @@ $SIGNATURES
 `sat_positions`: Matrix of satellite positions
 """
 function calc_H(sat_positions, ξ)
-    mapreduce(sat_pos -> [transpose(calc_e(sat_pos, ξ)) 1], vcat, eachcol(sat_positions))
+    n = size(sat_positions, 2)
+    H = Matrix{Float64}(undef, n, 4)
+    for j in 1:n
+        sat_pos = SVector{3}(view(sat_positions, :, j))
+        e = calc_e(sat_pos, ξ)
+        H[j, 1] = e[1]
+        H[j, 2] = e[2]
+        H[j, 3] = e[3]
+        H[j, 4] = 1.0
+    end
+    return H
 end
 
 """
@@ -107,19 +120,22 @@ $SIGNATURES
 
 Calculates the user velocity and clock drift
 """
-function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, ξ, states)
-    sat_positions = map(get_sat_position, sat_positions_and_velocities)
-    sat_positions_mat = reduce(hcat, sat_positions)
-    sat_clock_drifts = map(calc_satellite_clock_drift, states)
-    sat_dopplers = map(x -> upreferred(x.carrier_doppler / Hz), states)
-    H = collect(calc_H(sat_positions_mat, ξ))
+function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, ξ, states, H)
     center_frequency = get_center_frequency(first(states).system)
     λ = SPEEDOFLIGHT / upreferred(center_frequency / Hz)
-    y =
-        -(sat_dopplers * λ -
-        sat_clock_drifts * SPEEDOFLIGHT -
-        map(x -> dot(calc_e(get_sat_position(x), ξ), get_sat_velocity(x)), sat_positions_and_velocities))
-    H \ y
+    n = length(states)
+    y = Vector{Float64}(undef, n)
+    for j in 1:n
+        state = states[j]
+        sat_pv = sat_positions_and_velocities[j]
+        doppler = upreferred(state.carrier_doppler / Hz)
+        clock_drift = calc_satellite_clock_drift(state)
+        e = calc_e(get_sat_position(sat_pv), ξ)
+        y[j] = -(doppler * λ - clock_drift * SPEEDOFLIGHT - dot(e, get_sat_velocity(sat_pv)))
+    end
+    HtH = SMatrix{4,4}(H' * H)
+    Hty = SVector{4}(H' * y)
+    HtH \ Hty
 end
 
 get_sat_position(x) = x.position

--- a/src/user_position.jl
+++ b/src/user_position.jl
@@ -133,9 +133,16 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, ξ, st
         e = calc_e(get_sat_position(sat_pv), ξ)
         y[j] = -(doppler * λ - clock_drift * SPEEDOFLIGHT - dot(e, get_sat_velocity(sat_pv)))
     end
-    HtH = SMatrix{4,4}(H' * H)
-    Hty = SVector{4}(H' * y)
-    HtH \ Hty
+    _solve_velocity_qr(Val(n), H, y)
+end
+
+@generated function _solve_velocity_qr(::Val{n}, H, y) where {n}
+    quote
+        Hs = SMatrix{$n, 4}(H)
+        ys = SVector{$n}(y)
+        F = qr(Hs)
+        SMatrix{4,4}(F.R) \ (F.Q' * ys)
+    end
 end
 
 get_sat_position(x) = x.position


### PR DESCRIPTION
## Summary
Three changes against the GPS-9sat warm path (605 allocs / 73.8 KB on master):

1. **Rewrite `calc_H` without `mapreduce(...; vcat)`.** The original O(n²) reallocation pattern is replaced with a single `Matrix` allocation and direct fills.
2. **Reuse `H` between `calc_user_velocity_and_clock_drift` and `calc_DOP`.** Previously built twice; now built once after the LM solve and threaded through both consumers.
3. **Solve velocity LSQ via static-size QR.** `H \ y` allocated a 36 KB QR workspace per call. Replaced with a `@generated` function that converts `H` to `SMatrix{n,4}` and `y` to `SVector{n}`, runs StaticArrays' QR (stack-allocated), and solves `R x = Q' y`. Zero allocations, ~20% faster than the linear solve in isolation, and preserves QR's numerical stability — no condition-number squaring vs the normal-equations alternative. Each unique satellite count `n` triggers one specialization (in practice n ranges over ~4–14).

Also dropped `ξ[1:3]` slice allocations in `calc_e` and `calc_ρ_hat` (now `SVector{3}(ξ[1], ξ[2], ξ[3])`), and made `calc_ρ_hat` write into a preallocated `Vector` instead of `map`.

## Per-component allocations (GPS-9sat warm)
| Component | master | branch | Δ |
|---|---:|---:|---:|
| `user_position` (LM) | 10,304 B | 4,880 B | –53% |
| `calc_user_velocity_and_clock_drift` | 47,896 B | 6,368 B | –87% |
| `calc_H` + `reduce(hcat, ...)` | 3,696 B | 672 B | –82% |
| **Total** | **74,912 B** | **25,880 B** | **–65%** |

## End-to-end (BenchmarkTools minimum, samples=200)
| Suite | master | branch | Δ |
|---|---:|---:|---:|
| GPSL1 9sats warm | 44.3 µs | 23.0 µs | –48% |
| GPSL1 9sats cold | 67.9 µs | 34.0 µs | –50% |
| Galileo 5sats warm | 30.5 µs | 17.6 µs | –42% |
| Galileo 4sats warm | 26.0 µs | 16.9 µs | –35% |

## API change
`calc_user_velocity_and_clock_drift` gains a positional `H` argument. The function is internal (not exported, single call site in `calc_pvt`), so this is a non-breaking refactor.

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — all 7 testsets (Aqua + 6 PVT scenarios × 7 asserts each) pass.
- [x] AirspeedVelocity workflow comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)