### PR TITLE
perf: stack-allocate calc_DOP and reuse times in velocity solve

### DIFF
--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -243,7 +243,7 @@ function calc_pvt(
     sat_positions_mat = reduce(hcat, sat_positions)
     H = calc_H(sat_positions_mat, ξ)
     user_velocity_and_clock_drift = calc_user_velocity_and_clock_drift(
-        sat_positions_and_velocities, ξ, healthy_states, H)
+        sat_positions_and_velocities, ξ, healthy_states, times, H)
     position = ECEF(ξ[1], ξ[2], ξ[3])
     velocity = ECEF(
         user_velocity_and_clock_drift[1],

--- a/src/sat_time.jl
+++ b/src/sat_time.jl
@@ -35,11 +35,6 @@ function calc_satellite_clock_drift(decoder::GNSSDecoder.GNSSDecoderState, t)
     decoder.data.a_f2 * t * 2
 end
 
-function calc_satellite_clock_drift(state::SatelliteState)
-    approximated_time = calc_uncorrected_time(state)
-    calc_satellite_clock_drift(state.decoder, approximated_time)
-end
-
 function correct_by_group_delay(
     decoder::GNSSDecoder.GNSSDecoderState{<:GNSSDecoder.GPSL1Data},
     t,

--- a/src/user_position.jl
+++ b/src/user_position.jl
@@ -74,7 +74,7 @@ $SIGNATURES
 `H_GEO`: Geometry matrix
 """
 function calc_DOP(H_GEO)
-    D = inv(Symmetric(collect(H_GEO' * H_GEO)))
+    D = inv(SMatrix{4,4}(H_GEO' * H_GEO))
     if D[4, 4] < 0 ||
         D[3, 3] < 0 ||
         D[1, 1] + D[2, 2] < 0 ||
@@ -120,7 +120,7 @@ $SIGNATURES
 
 Calculates the user velocity and clock drift
 """
-function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, ξ, states, H)
+function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, ξ, states, times, H)
     center_frequency = get_center_frequency(first(states).system)
     λ = SPEEDOFLIGHT / upreferred(center_frequency / Hz)
     n = length(states)
@@ -129,7 +129,7 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, ξ, st
         state = states[j]
         sat_pv = sat_positions_and_velocities[j]
         doppler = upreferred(state.carrier_doppler / Hz)
-        clock_drift = calc_satellite_clock_drift(state)
+        clock_drift = calc_satellite_clock_drift(state.decoder, times[j])
         e = calc_e(get_sat_position(sat_pv), ξ)
         y[j] = -(doppler * λ - clock_drift * SPEEDOFLIGHT - dot(e, get_sat_velocity(sat_pv)))
     end


### PR DESCRIPTION
## Summary
Two follow-up cleanups identified by per-function profiling after #26.

1. **`calc_DOP`** uses `SMatrix{4,4}` for the `H'H` inverse. The product is always 4×4 regardless of satellite count, so a static-size inverse stack-allocates.
2. **`calc_user_velocity_and_clock_drift`** takes the already-computed `times` from `calc_pvt` instead of re-running `calc_uncorrected_time` per satellite via `calc_satellite_clock_drift(state)`.

The clock-drift change feeds the corrected time (rather than uncorrected) into the drift polynomial. With `a_f2 ~ 1e-19 s/s²` and time differences at the millisecond scale, the result moves by `~1e-22` — well below input noise.

## Per-function deltas (GPS-9sat warm, vs current master)
| Component | master | branch | Δ |
|---|---:|---:|---:|
| `calc_DOP` | 942 ns / 3,256 B / 20 allocs | **190 ns / 208 B / 2 allocs** | –80% time, –94% bytes |
| `calc_user_velocity_and_clock_drift` | 2,575 ns / 6,368 B / 120 allocs | **1,482 ns / 1,328 B / 75 allocs** | –42% time, –79% bytes |

## End-to-end (BenchmarkTools minimum, n=200)
| Suite | master | branch | Δ |
|---|---:|---:|---:|
| GPSL1 9sats warm | 22.8 µs / 25.9 KB | **19.5 µs / 17.8 KB** | –14% time, –31% bytes |
| GPSL1 9sats cold | 34.1 µs / 35.3 KB | **30.3 µs / 27.2 KB** | –11% time, –23% bytes |
| Galileo 5sats warm | 18.0 µs / 19.0 KB | **15.1 µs / 12.8 KB** | –16% time, –32% bytes |
| Galileo 4sats warm | 17.2 µs / 17.7 KB | **14.6 µs / 11.9 KB** | –15% time, –33% bytes |

## API change
`calc_user_velocity_and_clock_drift` gains a positional `times` argument between `states` and `H`. Internal function (not exported, single call site), non-breaking.

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` passes (Aqua + 6 PVT scenarios × 7 asserts).
- [ ] AirspeedVelocity workflow comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)