### PR TITLE
perf: avoid materializing healthy_states via findall + view

### DIFF
--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -225,10 +225,9 @@ function calc_pvt(
     all(state -> state.system == states[1].system, states) ||
         ArgumentError("For now all satellites need to be base on the same GNSS")
     system = first(states).system
-    healthy_states = filter(x -> is_sat_healthy(x.decoder), states)
-    if length(healthy_states) < 4
-        return prev_pvt
-    end
+    healthy_indices = findall(x -> is_sat_healthy(x.decoder), states)
+    length(healthy_indices) < 4 && return prev_pvt
+    healthy_states = view(states, healthy_indices)
     prev_ξ = [prev_pvt.position; prev_pvt.time_correction]
     healthy_prns = map(state -> state.decoder.prn, healthy_states)
     times = map(state -> calc_corrected_time(state), healthy_states)


### PR DESCRIPTION
## Summary
`filter(...)` materialized a fresh `Vector{SatelliteState}` of healthy states. With #28's parameterized `SatelliteState`, each instance is ~330 bytes by value, so 9 GPS sats + filter's internal buffers cost ~10.9 KB / 3 allocs — the largest single byte chunk remaining in `calc_pvt`'s warm path (57% of bytes).

Replace with `findall` → `view`. The `SubArray` supports `length`, `first`, indexing, and `map` — all the operations the downstream code uses, so the rest of `calc_pvt` is untouched.

## Per-step measurement (GPS-9sat)
| | master | branch | Δ |
|---|---:|---:|---:|
| `filter` healthy | 1,322 ns / 10,888 B / 3 allocs | – | – |
| `findall` + `view` | – | 90 ns / 224 B / 5 allocs | **–93% time, –98% bytes** |

## End-to-end (BenchmarkTools minimum, n=200)
| Suite | master | branch | Δ |
|---|---|---|---:|
| GPSL1 9sats warm | 11.8 µs / 19.0 KB | **10.3 µs / 8.4 KB** | –13% time, **–56% bytes** |
| GPSL1 9sats cold | 19.0 µs / 21.2 KB | **17.2 µs / 10.7 KB** | –9% time, **–50% bytes** |
| Galileo 5sats cold | 13.6 µs / 15.1 KB | **12.6 µs / 9.0 KB** | –7% time, –40% bytes |
| Galileo 4sats warm | 6.4 µs / 11.4 KB | **6.3 µs / 6.5 KB** | –43% bytes |

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` passes (Aqua + 6 PVT scenarios × 7 asserts).
- [ ] AirspeedVelocity workflow comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)