### PR TITLE
feat: support GNSSDecoder 2

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
         with:
           julia-version: '1'
-          extra-pkgs: BitIntegers,GNSSDecoder,GNSSSignals,Unitful
+          extra-pkgs: GNSSDecoder,GNSSSignals,Unitful
           bench-on: ${{github.event.pull_request.head.sha}}
           exeflags: '--threads=auto'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,11 @@ jobs:
         os:
           - ubuntu-latest
         include:
-          - os: windows-latest
-            version: '1'
+          # windows-latest is unsupported since GNSSDecoder 2: it depends on
+          # Aff3ct, whose aff3ct_jll ships no Windows binaries. Restore this
+          # entry once Aff3ct gains Windows support.
+          #- os: windows-latest
+          #  version: '1'
           - os: macOS-latest
             version: '1'
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -26,11 +26,10 @@ PositionVelocityTimeTrackingExt = "Tracking"
 [compat]
 Aqua = "0.8"
 AstroTime = "0.7"
-BitIntegers = "0.2.6, 0.3.5"
 CoordinateTransformations = "0.6"
 Dates = "1"
 DocStringExtensions = "0.6, 0.7, 0.8, 0.9"
-GNSSDecoder = "1.3"
+GNSSDecoder = "2"
 GNSSSignals = "2"
 Geodesy = "0.5, 1.0"
 LinearAlgebra = "1"
@@ -44,9 +43,8 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracking = "10b2438b-ffd4-5096-aa58-44041d5c8f3b"
 
 [targets]
-test = ["Test", "BitIntegers", "Aqua", "Tracking"]
+test = ["Test", "Aqua", "Tracking"]

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 GNSSDecoder = "bf6b1ec8-12ad-4501-972c-3dec0d675c2b"
 GNSSSignals = "52c80523-2a4e-5c38-8979-05588f836870"
 PositionVelocityTime = "52ec0b5e-ee36-11ea-211c-3d844fc5682d"

--- a/benchmark/fixtures.jl
+++ b/benchmark/fixtures.jl
@@ -2,29 +2,53 @@
 # These are used as inputs to `calc_pvt` benchmarks so that timings reflect
 # realistic decoder data and a converging least-squares geometry.
 
-using BitIntegers
 using GNSSDecoder
 using GNSSSignals
 using PositionVelocityTime
 using Unitful: Hz
 
-BitIntegers.@define_integers 288
-BitIntegers.@define_integers 320
-
-# GNSSSignals renamed GPSL1 -> GPSL1CA in v2. AirspeedVelocity runs this script
-# against both the PR and the base revision, which may resolve either GNSSSignals
-# major version, so pick whichever GPS L1 C/A type this version provides.
+# AirspeedVelocity runs this script against both the PR and the base revision,
+# which may resolve either major version of GNSSSignals/GNSSDecoder. v2 renamed
+# the GPS L1 C/A types (GPSL1* -> GPSL1CA*), so pick whichever this version
+# provides.
 const GPSL1CASystem = isdefined(GNSSSignals, :GPSL1CA) ? GNSSSignals.GPSL1CA : GNSSSignals.GPSL1
+const GPSDataType = isdefined(GNSSDecoder, :GPSL1CAData) ? GNSSDecoder.GPSL1CAData : GNSSDecoder.GPSL1Data
+const GPSConstantsType =
+    isdefined(GNSSDecoder, :GPSL1CAConstants) ? GNSSDecoder.GPSL1CAConstants :
+    GNSSDecoder.GPSL1Constants
+const GPSCacheType =
+    isdefined(GNSSDecoder, :GPSL1CACache) ? GNSSDecoder.GPSL1CACache : GNSSDecoder.GPSL1Cache
+
+# v2's soft-symbol decoder dropped the packed-bit `raw_buffer`/`buffer` fields and
+# `num_bits_buffered` from GNSSDecoderState. Construct positionally for whichever
+# layout the resolved GNSSDecoder version exposes; the bit buffers are irrelevant
+# to `calc_pvt`, so they default to zero on the older layout.
+function decoder_state(prn, raw_data, data, constants, cache, num_bits_after, is_shifted)
+    if :raw_buffer in fieldnames(GNSSDecoder.GNSSDecoderState)
+        return GNSSDecoderState(
+            prn,
+            zero(UInt128),
+            zero(UInt128),
+            raw_data,
+            data,
+            constants,
+            cache,
+            0,
+            num_bits_after,
+            is_shifted,
+        )
+    else
+        return GNSSDecoderState(prn, raw_data, data, constants, cache, num_bits_after, is_shifted)
+    end
+end
 
 "5 Galileo E1B satellites over Aachen, 2021-05-31 (from test/pvt.jl)."
 function make_galileo_states()
     galileo_e1b = GalileoE1B()
     states = [
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 2,
-                uint288"0x4001ec23bff8485200005ec5ff7a895805f4d37fe877968040ae99fffd20b00d205dcf80",
-                uint288"0xd2a6aec5828003d8477ff090a40000bd8bfef512b00be9a6ffd0ef2d00815d33fffa4160",
                 GNSSDecoder.GalileoE1BData(
                     WN = 1136,
                     TOW = 132769,
@@ -108,7 +132,6 @@ function make_galileo_states()
                     -4.442807309e-10,
                 ),
                 GNSSDecoder.GalileoE1BCache(),
-                49,
                 1549,
                 false,
             ),
@@ -118,10 +141,8 @@ function make_galileo_states()
             carrier_phase = -1.461823180908076,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 4,
-                uint288"0xc3ffc21fe800f025ffffeba64010c2fcff43fd5002fd6eaff7f228c000c1e9fe5bc6460f",
-                uint288"0xd158f0c583c003de017ff0fda00001459bfef3d0300bc02affd029150080dd73fff3e160",
                 GNSSDecoder.GalileoE1BData(
                     WN = 1136,
                     TOW = 132769,
@@ -205,7 +226,6 @@ function make_galileo_states()
                     -4.442807309e-10,
                 ),
                 GNSSDecoder.GalileoE1BCache(),
-                46,
                 1546,
                 true,
             ),
@@ -215,10 +235,8 @@ function make_galileo_states()
             carrier_phase = -2.3877702498883373,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 11,
-                uint288"0x8007b086ffe1b77000036397fde280e017a75dffa08a320100aa47ffeec2c03481373e00",
-                uint288"0xd4878bc5834003d8437ff0dbb80001b1cbfef140700bd3aeffd0451900805523fff76160",
                 GNSSDecoder.GalileoE1BData(
                     WN = 1136,
                     TOW = 132769,
@@ -302,7 +320,6 @@ function make_galileo_states()
                     -4.442807309e-10,
                 ),
                 GNSSDecoder.GalileoE1BCache(),
-                51,
                 1551,
                 false,
             ),
@@ -312,10 +329,8 @@ function make_galileo_states()
             carrier_phase = -1.4138935647217596,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 25,
-                uint288"0x7fff0d5ea003cad0ffffe78900422343fd0b07400be9b7bfdf65a700010ba7f96fe9183f",
-                uint288"0xd1dbd245820003ca857ff0d4bc000061dbfef772f00bd3e2ffd0592100826963fffbd160",
                 GNSSDecoder.GalileoE1BData(
                     WN = 1136,
                     TOW = 132769,
@@ -399,7 +414,6 @@ function make_galileo_states()
                     -4.442807309e-10,
                 ),
                 GNSSDecoder.GalileoE1BCache(),
-                48,
                 1548,
                 true,
             ),
@@ -409,10 +423,8 @@ function make_galileo_states()
             carrier_phase = -1.721713905186919,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 30,
-                uint288"0xa7ff845f3001e40b7fffe54480215fd1fe85d2a005fd7cdfefff5b800197d3fcb7a08c1f",
-                uint288"0xd3f0160582c003dd067ff0dfa40000d5dbfef501700bd16affd0141900800523fff34160",
                 GNSSDecoder.GalileoE1BData(
                     WN = 1136,
                     TOW = 132769,
@@ -496,7 +508,6 @@ function make_galileo_states()
                     -4.442807309e-10,
                 ),
                 GNSSDecoder.GalileoE1BCache(),
-                47,
                 1547,
                 true,
             ),
@@ -514,11 +525,9 @@ function make_gps_states()
     gpsl1 = GPSL1CASystem()
     states = [
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 7,
-                uint320"0xe2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07090f36c308b01c020ace4d54",
-                uint320"0x0048b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07090f36c308b",
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -556,7 +565,7 @@ function make_gps_states()
                     IODE_Sub_3 = "01000110",
                     i_dot = 1.657211886669833e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -594,7 +603,7 @@ function make_gps_states()
                     IODE_Sub_3 = "01000110",
                     i_dot = 1.657211886669833e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GPSConstantsType(
                     300,
                     0x8b,
                     8,
@@ -605,8 +614,7 @@ function make_gps_states()
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GPSCacheType(),
                 360,
                 false,
             ),
@@ -616,11 +624,9 @@ function make_gps_states()
             carrier_phase = 0.09402551301430394,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 8,
-                uint320"0xe2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07090f36c308b01c020ace4d54",
-                uint320"0xaf88b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07090f36c308b",
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -658,7 +664,7 @@ function make_gps_states()
                     IODE_Sub_3 = "01100111",
                     i_dot = -1.353627812603161e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -696,7 +702,7 @@ function make_gps_states()
                     IODE_Sub_3 = "01100111",
                     i_dot = -1.353627812603161e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GPSConstantsType(
                     300,
                     0x8b,
                     8,
@@ -707,8 +713,7 @@ function make_gps_states()
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GPSCacheType(),
                 360,
                 false,
             ),
@@ -718,11 +723,9 @@ function make_gps_states()
             carrier_phase = 2.7614518715603946,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 10,
-                uint320"0x1d3db86b3655d4396b13e1f30d99b57860edf0be15870e004a0193f8f59c1513374fe3fdf531b2ab",
-                uint320"0xdf48b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c070a63eaecc8b",
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -760,7 +763,7 @@ function make_gps_states()
                     IODE_Sub_3 = "00101000",
                     i_dot = 3.893019302737323e-11,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -798,7 +801,7 @@ function make_gps_states()
                     IODE_Sub_3 = "00101000",
                     i_dot = 3.893019302737323e-11,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GPSConstantsType(
                     300,
                     0x8b,
                     8,
@@ -809,8 +812,7 @@ function make_gps_states()
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GPSCacheType(),
                 360,
                 true,
             ),
@@ -820,11 +822,9 @@ function make_gps_states()
             carrier_phase = -0.7447786034769108,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 15,
-                uint320"0xe2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07084f478988b01c020ace4d54",
-                uint320"0x4fc8b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07084f478988b",
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -862,7 +862,7 @@ function make_gps_states()
                     IODE_Sub_3 = "01011001",
                     i_dot = 3.010839699272994e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -900,7 +900,7 @@ function make_gps_states()
                     IODE_Sub_3 = "01011001",
                     i_dot = 3.010839699272994e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GPSConstantsType(
                     300,
                     0x8b,
                     8,
@@ -911,8 +911,7 @@ function make_gps_states()
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GPSCacheType(),
                 360,
                 false,
             ),
@@ -922,11 +921,9 @@ function make_gps_states()
             carrier_phase = -0.22375187424152987,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 16,
-                uint320"0xe2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07084f478988b01c020ace4d54",
-                uint320"0x9d88b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07084f478988b",
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -964,7 +961,7 @@ function make_gps_states()
                     IODE_Sub_3 = "00100010",
                     i_dot = -2.95012288445966e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -1002,7 +999,7 @@ function make_gps_states()
                     IODE_Sub_3 = "00100010",
                     i_dot = -2.95012288445966e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GPSConstantsType(
                     300,
                     0x8b,
                     8,
@@ -1013,8 +1010,7 @@ function make_gps_states()
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GPSCacheType(),
                 360,
                 false,
             ),
@@ -1024,11 +1020,9 @@ function make_gps_states()
             carrier_phase = 2.59152430602131,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 18,
-                uint320"0x1d3db86b3655d4396b13e1f30d99b57860edf0be15870e004a0193f8f729761f374fe3fdf531b2ab",
-                uint320"0x9b08b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c0708d689e0c8b",
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -1066,7 +1060,7 @@ function make_gps_states()
                     IODE_Sub_3 = "11100001",
                     i_dot = -1.0071848104329588e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -1104,7 +1098,7 @@ function make_gps_states()
                     IODE_Sub_3 = "11100001",
                     i_dot = -1.0071848104329588e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GPSConstantsType(
                     300,
                     0x8b,
                     8,
@@ -1115,8 +1109,7 @@ function make_gps_states()
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GPSCacheType(),
                 360,
                 true,
             ),
@@ -1126,11 +1119,9 @@ function make_gps_states()
             carrier_phase = -0.7416765461612318,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 23,
-                uint320"0x1d3db86b3655d4396b13e1f30d99b57860edf0be15870e004a0193f8f6f0c93cf74fe3fdf531b2ab",
-                uint320"0x8fc8b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07090f36c308b",
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -1168,7 +1159,7 @@ function make_gps_states()
                     IODE_Sub_3 = "11101110",
                     i_dot = 3.107272287505937e-11,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -1206,7 +1197,7 @@ function make_gps_states()
                     IODE_Sub_3 = "11101110",
                     i_dot = 3.107272287505937e-11,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GPSConstantsType(
                     300,
                     0x8b,
                     8,
@@ -1217,8 +1208,7 @@ function make_gps_states()
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GPSCacheType(),
                 360,
                 true,
             ),
@@ -1228,11 +1218,9 @@ function make_gps_states()
             carrier_phase = -0.7597910878699417,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 26,
-                uint320"0x1d3db86b3655d4396b13e1f30d99b57860edf0be15870e004a0193f8f729761f374fe3fdf531b2ab",
-                uint320"0x3ac8b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c0708d689e0c8b",
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -1270,7 +1258,7 @@ function make_gps_states()
                     IODE_Sub_3 = "01101110",
                     i_dot = -3.328710082707509e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -1308,7 +1296,7 @@ function make_gps_states()
                     IODE_Sub_3 = "01101110",
                     i_dot = -3.328710082707509e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GPSConstantsType(
                     300,
                     0x8b,
                     8,
@@ -1319,8 +1307,7 @@ function make_gps_states()
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GPSCacheType(),
                 360,
                 true,
             ),
@@ -1330,11 +1317,9 @@ function make_gps_states()
             carrier_phase = -2.1444956909602526,
         ),
         SatelliteState(;
-            decoder = GNSSDecoderState(
+            decoder = decoder_state(
                 27,
-                uint320"0xe2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c070a63eaecc8b01c020ace4d54",
-                uint320"0x75c8b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c070a63eaecc8b",
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -1372,7 +1357,7 @@ function make_gps_states()
                     IODE_Sub_3 = "01001110",
                     i_dot = -1.2286226056345314e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GPSDataType(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -1410,7 +1395,7 @@ function make_gps_states()
                     IODE_Sub_3 = "01001110",
                     i_dot = -1.2286226056345314e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GPSConstantsType(
                     300,
                     0x8b,
                     8,
@@ -1421,8 +1406,7 @@ function make_gps_states()
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GPSCacheType(),
                 360,
                 false,
             ),

--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -374,7 +374,7 @@ function get_frequency_offset(pvt::PVTSolution, base_frequency)
 end
 
 function get_system_start_time(
-    decoder::GNSSDecoder.GNSSDecoderState{<:GNSSDecoder.GPSL1Data},
+    decoder::GNSSDecoder.GNSSDecoderState{<:GNSSDecoder.GPSL1CAData},
 )
     TAIEpoch(1980, 1, 6, 0, 0, 19.0) # There were 19 leap seconds at 01/06/1999 compared to UTC
 end
@@ -386,7 +386,7 @@ function get_system_start_time(
 end
 
 """
-    get_week(decoder::GNSSDecoderState{<:GPSL1Data}; approximate_year)
+    get_week(decoder::GNSSDecoderState{<:GPSL1CAData}; approximate_year)
 
 Return the absolute GPS week number for a GPSL1 decoder, resolving the
 1024-week rollover ambiguity using `approximate_year` as a calendar
@@ -405,7 +405,7 @@ For Galileo, the broadcast WN is 12 bits and does not need this
 treatment in any practical operational scenario.
 """
 function get_week(
-    decoder::GNSSDecoder.GNSSDecoderState{<:GNSSDecoder.GPSL1Data};
+    decoder::GNSSDecoder.GNSSDecoderState{<:GNSSDecoder.GPSL1CAData};
     approximate_year::Integer = year(now(UTC)),
 )
     # GPS week 0 begins 1980-01-06. Compute the integer week count from

--- a/src/ionosphere.jl
+++ b/src/ionosphere.jl
@@ -30,7 +30,7 @@ const _GPS_L1_FREQUENCY = GNSSSignals.get_center_frequency(GPSL1CA())
 
 The eight Klobuchar ionospheric coefficients decoded from a GPS L1 navigation
 message, in IS-GPS-200 SI units (seconds and seconds·semicircle⁻ⁿ). The field
-names mirror `GNSSDecoder.GPSL1Data` (`α_0…α_3`, `β_0…β_3`).
+names mirror `GNSSDecoder.GPSL1CAData` (`α_0…α_3`, `β_0…β_3`).
 """
 struct KlobucharParams
     α_0::Float64
@@ -64,7 +64,7 @@ Klobuchar α/β decoded from a GPS L1 navigation message, or `nothing` if they h
 not been broadcast yet (subframe 4, page 18) or the decoder is not GPS L1.
 """
 klobuchar_params(decoder) = nothing
-function klobuchar_params(decoder::GNSSDecoder.GNSSDecoderState{<:GNSSDecoder.GPSL1Data})
+function klobuchar_params(decoder::GNSSDecoder.GNSSDecoderState{<:GNSSDecoder.GPSL1CAData})
     d = decoder.data
     (isnothing(d.α_0) || isnothing(d.β_0)) && return nothing
     return KlobucharParams(d.α_0, d.α_1, d.α_2, d.α_3, d.β_0, d.β_1, d.β_2, d.β_3)

--- a/src/sat_time.jl
+++ b/src/sat_time.jl
@@ -36,7 +36,7 @@ function calc_satellite_clock_drift(decoder::GNSSDecoder.GNSSDecoderState, t)
 end
 
 function correct_by_group_delay(
-    decoder::GNSSDecoder.GNSSDecoderState{<:GNSSDecoder.GPSL1Data},
+    decoder::GNSSDecoder.GNSSDecoderState{<:GNSSDecoder.GPSL1CAData},
     t,
 )
     t - decoder.data.T_GD

--- a/test/get_week.jl
+++ b/test/get_week.jl
@@ -1,13 +1,13 @@
 using PositionVelocityTime: get_week
-using GNSSDecoder: GNSSDecoderState, GPSL1Data
+using GNSSDecoder: GNSSDecoderState, GPSL1CAData
 using GNSSSignals: GPSL1CA, GalileoE1B
 
-# Build a minimal GNSSDecoderState{GPSL1Data} with the given broadcast
+# Build a minimal GNSSDecoderState{GPSL1CAData} with the given broadcast
 # 10-bit `trans_week`. `get_week` only reads `decoder.data.trans_week`
 # so the rest of the state can stay at its default zero values.
 function decoder_with_trans_week(trans_week)
     base = GNSSDecoderState(GPSL1CA(), 1)
-    GNSSDecoderState(base; data = GPSL1Data(base.data; trans_week))
+    GNSSDecoderState(base; data = GPSL1CAData(base.data; trans_week))
 end
 
 @testset "get_week resolves GPS L1 week-rollover ambiguity" begin

--- a/test/ionosphere.jl
+++ b/test/ionosphere.jl
@@ -59,7 +59,7 @@ end
         dec = GNSSDecoderState(GPSL1CA(), 1)
         GNSSDecoder.GNSSDecoderState(
             dec;
-            data = GNSSDecoder.GPSL1Data(
+            data = GNSSDecoder.GPSL1CAData(
                 dec.data;
                 α_0 = α[1],
                 α_1 = α[2],

--- a/test/pvt.jl
+++ b/test/pvt.jl
@@ -1,13 +1,9 @@
-BitIntegers.@define_integers 288
-BitIntegers.@define_integers 320
 @testset "PVT Galileo E1B with frequency offset of $freq_offset" for freq_offset in (0.0Hz, 500Hz, -1000Hz)
     galileo_e1b = GalileoE1B()
     states = [
         SatelliteState(;
             decoder = GNSSDecoderState(
                 2,
-                uint288"0x4001ec23bff8485200005ec5ff7a895805f4d37fe877968040ae99fffd20b00d205dcf80",
-                uint288"0xd2a6aec5828003d8477ff090a40000bd8bfef512b00be9a6ffd0ef2d00815d33fffa4160",
                 GNSSDecoder.GalileoE1BData(
                     WN = 1136,
                     TOW = 132769,
@@ -91,7 +87,6 @@ BitIntegers.@define_integers 320
                     -4.442807309e-10,
                 ),
                 GNSSDecoder.GalileoE1BCache(),
-                49,
                 1549,
                 false,
             ),
@@ -103,8 +98,6 @@ BitIntegers.@define_integers 320
         SatelliteState(;
             decoder = GNSSDecoderState(
                 4,
-                uint288"0xc3ffc21fe800f025ffffeba64010c2fcff43fd5002fd6eaff7f228c000c1e9fe5bc6460f",
-                uint288"0xd158f0c583c003de017ff0fda00001459bfef3d0300bc02affd029150080dd73fff3e160",
                 GNSSDecoder.GalileoE1BData(
                     WN = 1136,
                     TOW = 132769,
@@ -188,7 +181,6 @@ BitIntegers.@define_integers 320
                     -4.442807309e-10,
                 ),
                 GNSSDecoder.GalileoE1BCache(),
-                46,
                 1546,
                 true,
             ),
@@ -200,8 +192,6 @@ BitIntegers.@define_integers 320
         SatelliteState(;
             decoder = GNSSDecoderState(
                 11,
-                uint288"0x8007b086ffe1b77000036397fde280e017a75dffa08a320100aa47ffeec2c03481373e00",
-                uint288"0xd4878bc5834003d8437ff0dbb80001b1cbfef140700bd3aeffd0451900805523fff76160",
                 GNSSDecoder.GalileoE1BData(
                     WN = 1136,
                     TOW = 132769,
@@ -285,7 +275,6 @@ BitIntegers.@define_integers 320
                     -4.442807309e-10,
                 ),
                 GNSSDecoder.GalileoE1BCache(),
-                51,
                 1551,
                 false,
             ),
@@ -297,8 +286,6 @@ BitIntegers.@define_integers 320
         SatelliteState(;
             decoder = GNSSDecoderState(
                 25,
-                uint288"0x7fff0d5ea003cad0ffffe78900422343fd0b07400be9b7bfdf65a700010ba7f96fe9183f",
-                uint288"0xd1dbd245820003ca857ff0d4bc000061dbfef772f00bd3e2ffd0592100826963fffbd160",
                 GNSSDecoder.GalileoE1BData(
                     WN = 1136,
                     TOW = 132769,
@@ -382,7 +369,6 @@ BitIntegers.@define_integers 320
                     -4.442807309e-10,
                 ),
                 GNSSDecoder.GalileoE1BCache(),
-                48,
                 1548,
                 true,
             ),
@@ -394,8 +380,6 @@ BitIntegers.@define_integers 320
         SatelliteState(;
             decoder = GNSSDecoderState(
                 30,
-                uint288"0xa7ff845f3001e40b7fffe54480215fd1fe85d2a005fd7cdfefff5b800197d3fcb7a08c1f",
-                uint288"0xd3f0160582c003dd067ff0dfa40000d5dbfef501700bd16affd0141900800523fff34160",
                 GNSSDecoder.GalileoE1BData(
                     WN = 1136,
                     TOW = 132769,
@@ -479,7 +463,6 @@ BitIntegers.@define_integers 320
                     -4.442807309e-10,
                 ),
                 GNSSDecoder.GalileoE1BCache(),
-                47,
                 1547,
                 true,
             ),
@@ -524,9 +507,7 @@ end
         SatelliteState(;
             decoder = GNSSDecoderState(
                 7,
-                uint320"0xe2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07090f36c308b01c020ace4d54",
-                uint320"0x0048b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07090f36c308b",
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -564,7 +545,7 @@ end
                     IODE_Sub_3 = "01000110",
                     i_dot = 1.657211886669833e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -602,7 +583,7 @@ end
                     IODE_Sub_3 = "01000110",
                     i_dot = 1.657211886669833e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GNSSDecoder.GPSL1CAConstants(
                     300,
                     0x8b,
                     8,
@@ -613,8 +594,7 @@ end
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GNSSDecoder.GPSL1CACache(),
                 360,
                 false,
             ),
@@ -626,9 +606,7 @@ end
         SatelliteState(;
             decoder = GNSSDecoderState(
                 8,
-                uint320"0xe2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07090f36c308b01c020ace4d54",
-                uint320"0xaf88b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07090f36c308b",
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -666,7 +644,7 @@ end
                     IODE_Sub_3 = "01100111",
                     i_dot = -1.353627812603161e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -704,7 +682,7 @@ end
                     IODE_Sub_3 = "01100111",
                     i_dot = -1.353627812603161e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GNSSDecoder.GPSL1CAConstants(
                     300,
                     0x8b,
                     8,
@@ -715,8 +693,7 @@ end
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GNSSDecoder.GPSL1CACache(),
                 360,
                 false,
             ),
@@ -728,9 +705,7 @@ end
         SatelliteState(;
             decoder = GNSSDecoderState(
                 10,
-                uint320"0x1d3db86b3655d4396b13e1f30d99b57860edf0be15870e004a0193f8f59c1513374fe3fdf531b2ab",
-                uint320"0xdf48b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c070a63eaecc8b",
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -768,7 +743,7 @@ end
                     IODE_Sub_3 = "00101000",
                     i_dot = 3.893019302737323e-11,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -806,7 +781,7 @@ end
                     IODE_Sub_3 = "00101000",
                     i_dot = 3.893019302737323e-11,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GNSSDecoder.GPSL1CAConstants(
                     300,
                     0x8b,
                     8,
@@ -817,8 +792,7 @@ end
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GNSSDecoder.GPSL1CACache(),
                 360,
                 true,
             ),
@@ -830,9 +804,7 @@ end
         SatelliteState(;
             decoder = GNSSDecoderState(
                 15,
-                uint320"0xe2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07084f478988b01c020ace4d54",
-                uint320"0x4fc8b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07084f478988b",
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -870,7 +842,7 @@ end
                     IODE_Sub_3 = "01011001",
                     i_dot = 3.010839699272994e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -908,7 +880,7 @@ end
                     IODE_Sub_3 = "01011001",
                     i_dot = 3.010839699272994e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GNSSDecoder.GPSL1CAConstants(
                     300,
                     0x8b,
                     8,
@@ -919,8 +891,7 @@ end
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GNSSDecoder.GPSL1CACache(),
                 360,
                 false,
             ),
@@ -932,9 +903,7 @@ end
         SatelliteState(;
             decoder = GNSSDecoderState(
                 16,
-                uint320"0xe2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07084f478988b01c020ace4d54",
-                uint320"0x9d88b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07084f478988b",
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -972,7 +941,7 @@ end
                     IODE_Sub_3 = "00100010",
                     i_dot = -2.95012288445966e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -1010,7 +979,7 @@ end
                     IODE_Sub_3 = "00100010",
                     i_dot = -2.95012288445966e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GNSSDecoder.GPSL1CAConstants(
                     300,
                     0x8b,
                     8,
@@ -1021,8 +990,7 @@ end
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GNSSDecoder.GPSL1CACache(),
                 360,
                 false,
             ),
@@ -1034,9 +1002,7 @@ end
         SatelliteState(;
             decoder = GNSSDecoderState(
                 18,
-                uint320"0x1d3db86b3655d4396b13e1f30d99b57860edf0be15870e004a0193f8f729761f374fe3fdf531b2ab",
-                uint320"0x9b08b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c0708d689e0c8b",
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -1074,7 +1040,7 @@ end
                     IODE_Sub_3 = "11100001",
                     i_dot = -1.0071848104329588e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -1112,7 +1078,7 @@ end
                     IODE_Sub_3 = "11100001",
                     i_dot = -1.0071848104329588e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GNSSDecoder.GPSL1CAConstants(
                     300,
                     0x8b,
                     8,
@@ -1123,8 +1089,7 @@ end
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GNSSDecoder.GPSL1CACache(),
                 360,
                 true,
             ),
@@ -1136,9 +1101,7 @@ end
         SatelliteState(;
             decoder = GNSSDecoderState(
                 23,
-                uint320"0x1d3db86b3655d4396b13e1f30d99b57860edf0be15870e004a0193f8f6f0c93cf74fe3fdf531b2ab",
-                uint320"0x8fc8b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c07090f36c308b",
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -1176,7 +1139,7 @@ end
                     IODE_Sub_3 = "11101110",
                     i_dot = 3.107272287505937e-11,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -1214,7 +1177,7 @@ end
                     IODE_Sub_3 = "11101110",
                     i_dot = 3.107272287505937e-11,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GNSSDecoder.GPSL1CAConstants(
                     300,
                     0x8b,
                     8,
@@ -1225,8 +1188,7 @@ end
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GNSSDecoder.GPSL1CACache(),
                 360,
                 true,
             ),
@@ -1238,9 +1200,7 @@ end
         SatelliteState(;
             decoder = GNSSDecoderState(
                 26,
-                uint320"0x1d3db86b3655d4396b13e1f30d99b57860edf0be15870e004a0193f8f729761f374fe3fdf531b2ab",
-                uint320"0x3ac8b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c0708d689e0c8b",
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -1278,7 +1238,7 @@ end
                     IODE_Sub_3 = "01101110",
                     i_dot = -3.328710082707509e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -1316,7 +1276,7 @@ end
                     IODE_Sub_3 = "01101110",
                     i_dot = -3.328710082707509e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GNSSDecoder.GPSL1CAConstants(
                     300,
                     0x8b,
                     8,
@@ -1327,8 +1287,7 @@ end
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GNSSDecoder.GPSL1CACache(),
                 360,
                 true,
             ),
@@ -1340,9 +1299,7 @@ end
         SatelliteState(;
             decoder = GNSSDecoderState(
                 27,
-                uint320"0xe2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c070a63eaecc8b01c020ace4d54",
-                uint320"0x75c8b01c020ace2c24794c9aa2bc694ec1e0cf2664a879f120f41ea78f1ffb5fe6c070a63eaecc8b",
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 4,
                     integrity_status_flag = false,
                     TOW = nothing,
@@ -1380,7 +1337,7 @@ end
                     IODE_Sub_3 = "01001110",
                     i_dot = -1.2286226056345314e-10,
                 ),
-                GNSSDecoder.GPSL1Data(
+                GNSSDecoder.GPSL1CAData(
                     last_subframe_id = 3,
                     integrity_status_flag = false,
                     TOW = 132768,
@@ -1418,7 +1375,7 @@ end
                     IODE_Sub_3 = "01001110",
                     i_dot = -1.2286226056345314e-10,
                 ),
-                GNSSDecoder.GPSL1Constants(
+                GNSSDecoder.GPSL1CAConstants(
                     300,
                     0x8b,
                     8,
@@ -1429,8 +1386,7 @@ end
                     3.986005e14,
                     -4.442807633e-10,
                 ),
-                GNSSDecoder.GPSL1Cache(),
-                60,
+                GNSSDecoder.GPSL1CACache(),
                 360,
                 false,
             ),

--- a/test/pvt_iono_tropo.jl
+++ b/test/pvt_iono_tropo.jl
@@ -1,11 +1,5 @@
 using LinearAlgebra: norm
 
-# Exact-width unsigned types backing the captured decoder bit buffers
-# (288-bit for Galileo E1B, 320-bit for GPS L1 C/A). Guarded so the file is
-# self-contained yet does not clash with the same definitions in `pvt.jl`.
-isdefined(@__MODULE__, :UInt288) || BitIntegers.@define_integers 288
-isdefined(@__MODULE__, :UInt320) || BitIntegers.@define_integers 320
-
 # Ground truth position
 const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
 
@@ -16,9 +10,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
             SatelliteState(;
                 decoder = GNSSDecoderState(
                     9,
-                    uint320"0xfffffac0000014ffffaf741b36875df7ac0111755517d5cdf8e80000ed4d11000f800004f20e38e3",
-                    uint320"0xf208baaa8beae71d80000000000000f8d15980b47fffffd6000000a7fffd7ba0d9b43aefbd60088b",
-                    GNSSDecoder.GPSL1Data(
+                    GNSSDecoder.GPSL1CAData(
                         last_subframe_id = 2,
                         integrity_status_flag = false,
                         TOW = 259242,
@@ -64,7 +56,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         β_2 = nothing,
                         β_3 = nothing,
                     ),
-                    GNSSDecoder.GPSL1Data(
+                    GNSSDecoder.GPSL1CAData(
                         last_subframe_id = 2,
                         integrity_status_flag = false,
                         TOW = 259242,
@@ -110,7 +102,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         β_2 = -65536.0,
                         β_3 = -393216.0,
                     ),
-                    GNSSDecoder.GPSL1Constants(
+                    GNSSDecoder.GPSL1CAConstants(
                         300,
                         0x8b,
                         8,
@@ -121,8 +113,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         3.986005e14,
                         -4.442807633e-10,
                     ),
-                    GNSSDecoder.GPSL1Cache(),
-                    173,
+                    GNSSDecoder.GPSL1CACache(),
                     173,
                     false,
                 ),
@@ -134,9 +125,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
             SatelliteState(;
                 decoder = GNSSDecoderState(
                     11,
-                    uint320"0x00000000000000000050d81b3686120853ef6e8aaae82a320717fffe20cd0c5197800004f20e38e3",
-                    uint320"0xf208baaa8beae71d800000000000017f5f5201ecfffffffffffffffffffd793f264bcf6fbd60848b",
-                    GNSSDecoder.GPSL1Data(
+                    GNSSDecoder.GPSL1CAData(
                         last_subframe_id = 2,
                         integrity_status_flag = false,
                         TOW = 259242,
@@ -182,7 +171,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         β_2 = nothing,
                         β_3 = nothing,
                     ),
-                    GNSSDecoder.GPSL1Data(
+                    GNSSDecoder.GPSL1CAData(
                         last_subframe_id = 2,
                         integrity_status_flag = false,
                         TOW = 259242,
@@ -228,7 +217,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         β_2 = -65536.0,
                         β_3 = -393216.0,
                     ),
-                    GNSSDecoder.GPSL1Constants(
+                    GNSSDecoder.GPSL1CAConstants(
                         300,
                         0x8b,
                         8,
@@ -239,8 +228,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         3.986005e14,
                         -4.442807633e-10,
                     ),
-                    GNSSDecoder.GPSL1Cache(),
-                    173,
+                    GNSSDecoder.GPSL1CACache(),
                     173,
                     true,
                 ),
@@ -252,9 +240,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
             SatelliteState(;
                 decoder = GNSSDecoderState(
                     17,
-                    uint320"0xffffffffffffffffffaf27e4c979edf7ac1091755517d5cdf8e800019ad6016e98bffffb190e38e3",
-                    uint320"0xf208baaa8beae71d8000000000000367d702b006fffffffffffffffffffd793f264bcf6fbd60848b",
-                    GNSSDecoder.GPSL1Data(
+                    GNSSDecoder.GPSL1CAData(
                         last_subframe_id = 2,
                         integrity_status_flag = false,
                         TOW = 259242,
@@ -300,7 +286,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         β_2 = nothing,
                         β_3 = nothing,
                     ),
-                    GNSSDecoder.GPSL1Data(
+                    GNSSDecoder.GPSL1CAData(
                         last_subframe_id = 2,
                         integrity_status_flag = false,
                         TOW = 259242,
@@ -346,7 +332,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         β_2 = -65536.0,
                         β_3 = -393216.0,
                     ),
-                    GNSSDecoder.GPSL1Constants(
+                    GNSSDecoder.GPSL1CAConstants(
                         300,
                         0x8b,
                         8,
@@ -357,8 +343,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         3.986005e14,
                         -4.442807633e-10,
                     ),
-                    GNSSDecoder.GPSL1Cache(),
-                    173,
+                    GNSSDecoder.GPSL1CACache(),
                     173,
                     false,
                 ),
@@ -370,9 +355,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
             SatelliteState(;
                 decoder = GNSSDecoderState(
                     27,
-                    uint320"0xfffffac0000014ffffaf741b36875df7ac0111755517d5cdf8e80000eafce6d996400004e6f1c71c",
-                    uint320"0xf208baaa8beae71d80000000000003d8fb25beea7fffffd6000000a7fffd7ba0d9b43aefbd60088b",
-                    GNSSDecoder.GPSL1Data(
+                    GNSSDecoder.GPSL1CAData(
                         last_subframe_id = 2,
                         integrity_status_flag = false,
                         TOW = 259242,
@@ -418,7 +401,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         β_2 = nothing,
                         β_3 = nothing,
                     ),
-                    GNSSDecoder.GPSL1Data(
+                    GNSSDecoder.GPSL1CAData(
                         last_subframe_id = 2,
                         integrity_status_flag = false,
                         TOW = 259242,
@@ -464,7 +447,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         β_2 = -65536.0,
                         β_3 = -393216.0,
                     ),
-                    GNSSDecoder.GPSL1Constants(
+                    GNSSDecoder.GPSL1CAConstants(
                         300,
                         0x8b,
                         8,
@@ -475,8 +458,7 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         3.986005e14,
                         -4.442807633e-10,
                     ),
-                    GNSSDecoder.GPSL1Cache(),
-                    173,
+                    GNSSDecoder.GPSL1CACache(),
                     173,
                     false,
                 ),
@@ -514,8 +496,6 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
             SatelliteState(;
                 decoder = GNSSDecoderState(
                     5,
-                    uint288"0xbfffffed00000047fffffe10000004bfffffeb04200f832fffe1e3c9ff809f5803ef0640",
-                    uint288"0xc00bdee5802000000c7fffffc4000000f7fffffda0000008ffffffc200000097fffffd60",
                     GNSSDecoder.GalileoE1BData(
                         WN = 1082,
                         TOW = 259279,
@@ -605,7 +585,6 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         -4.442807309e-10,
                     ),
                     GNSSDecoder.GalileoE1BCache(),
-                    141,
                     1391,
                     false,
                 ),
@@ -617,8 +596,6 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
             SatelliteState(;
                 decoder = GNSSDecoderState(
                     6,
-                    uint288"0xf7fffffda0000008ffffffc200000097fffffd608401f065fffc3c793ff013eb007de0c8",
-                    uint288"0xc00be565802000000c7fffffc4000000f7fffffda0000008ffffffc200000097fffffd60",
                     GNSSDecoder.GalileoE1BData(
                         WN = 1082,
                         TOW = 259279,
@@ -708,7 +685,6 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         -4.442807309e-10,
                     ),
                     GNSSDecoder.GalileoE1BCache(),
-                    138,
                     1388,
                     false,
                 ),
@@ -720,8 +696,6 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
             SatelliteState(;
                 decoder = GNSSDecoderState(
                     20,
-                    uint288"0x080000025ffffff70000003dffffff680000029f7bfe0f9a0003c386c00fec14ff821f37",
-                    uint288"0xc00bc465802000000c7fffffc4000000f7fffffda0000008ffffffc200000097fffffd60",
                     GNSSDecoder.GalileoE1BData(
                         WN = 1082,
                         TOW = 259279,
@@ -811,7 +785,6 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         -4.442807309e-10,
                     ),
                     GNSSDecoder.GalileoE1BCache(),
-                    138,
                     1388,
                     true,
                 ),
@@ -823,8 +796,6 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
             SatelliteState(;
                 decoder = GNSSDecoderState(
                     22,
-                    uint288"0x080000025ffffff70000003dffffff680000029f7bfe0f9a0003c386c00fec14ff821f37",
-                    uint288"0xc00bf825802000000c7fffffc4000000f7fffffda0000008ffffffc200000097fffffd60",
                     GNSSDecoder.GalileoE1BData(
                         WN = 1082,
                         TOW = 259279,
@@ -914,7 +885,6 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
                         -4.442807309e-10,
                     ),
                     GNSSDecoder.GalileoE1BCache(),
-                    138,
                     1388,
                     true,
                 ),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 
-using Test, PositionVelocityTime, GNSSDecoder, AstroTime, BitIntegers, GNSSSignals, Geodesy, Dates
+using Test, PositionVelocityTime, GNSSDecoder, AstroTime, GNSSSignals, Geodesy, Dates
 using Unitful: Hz
 
 include("aqua.jl")


### PR DESCRIPTION
## Summary

Bumps the `GNSSDecoder` compat to `2`. v2 is a ground-up redesign; the pieces PVT touches changed as follows:

| Symbol | v1.3 | v2 |
|---|---|---|
| GPS data struct | `GPSL1Data` | `GPSL1CAData` |
| GPS constants | `GPSL1Constants` | `GPSL1CAConstants` |
| GPS cache | `GPSL1Cache` | `GPSL1CACache` |
| `GNSSDecoderState` fields | had `raw_buffer`, `buffer`, `num_bits_buffered` | dropped (soft-symbol decoder no longer buffers packed bits) |

The headline v2 break (`decode` now takes soft symbols instead of packed bits) does not affect PVT, which never calls `decode`.

## Changes

- **Project.toml**: `GNSSDecoder = "1.3"` → `"2"`.
- **src/** (`sat_time.jl`, `ionosphere.jl`, `PositionVelocityTime.jl`): `GPSL1Data` → `GPSL1CAData` in type annotations. This is the only src change needed — PVT uses `GNSSDecoderState` purely as a type parameter and never reads the removed buffer fields.
- **test/**: applied the GPS struct renames and stripped the three dropped positional constructor args (`raw_buffer`, `buffer`, `num_bits_buffered`) from the positional `GNSSDecoderState(...)` calls. Verified the `*Constants` positional field order and the `GalileoE1B*` / `GPSL1CAData` field sets are unchanged between versions.
- Removed **BitIntegers** (dep/compat/test-target + the `UInt288`/`UInt320` defs) — it only existed to spell the captured bit-buffer literals, which no longer exist.

Versioning is left to the semantic-release CI; the `feat:` commit yields a minor bump.

## Test plan

- [x] Full test suite passes against GNSSDecoder 2.0.0 (564 assertions, Aqua included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)