### PR TITLE
build(deps): allow Tracking 3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ LinearAlgebra = "1"
 LsqFit = "0.12, 0.13, 0.14, 0.15, 0.16"
 StaticArrays = "1"
 Test = "1"
-Tracking = "2.2"
+Tracking = "3"
 Unitful = "1"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary

Tracking.jl 3.0.0 has been released. This widens the `Tracking` compat in `Project.toml` from `2.2` to `3`.

## Why no other code changes are required

The only breaking change in Tracking 3.0.0 is that multi-band `track`/`track!` measurement NamedTuples are now keyed by `GNSSSignals.get_band_id` (`:L1`, `:L2`, `:L5`) instead of Tracking's lowercase `band_key` (`:l1`…), and `Tracking.band_key` was removed.

PositionVelocityTime is unaffected:

- It derives band ids straight from `GNSSSignals.get_band_id` (already capitalized `:L1`/`:L5`), not from Tracking's measurement NamedTuples.
- The Tracking extension only uses `get_code_phase` / `get_carrier_doppler` / `get_carrier_phase` on a `TrackedSat`.
- The integration test only uses `track!`, `get_soft_bits`, and `get_sat_state` keyed by group (`:gps`) + PRN.

None of those APIs changed. GNSSSignals 3.3 (required by PVT 3.0.0) also matches Tracking 3.0.0's requirement, so there is no transitive conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)