### PR TITLE
perf: extract decoder data into concrete ephemeris and clock structs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -24,6 +24,19 @@ calc_satellite_position_and_velocity
 get_sat_enu
 ```
 
+## Ephemeris Extraction
+
+[`calc_pvt`](@ref) extracts each satellite's decoded broadcast orbit and clock model
+into concrete structs once per solve — a function barrier over the decoder's
+`Union{Nothing, …}` data fields that keeps the propagation and clock kernels
+allocation-free. These types are internal; they are documented here for reference.
+
+```@docs
+PositionVelocityTime.Ephemeris
+PositionVelocityTime.ClockModel
+PositionVelocityTime.orbital_terms
+```
+
 ## Atmospheric Corrections
 
 These corrections are applied automatically by [`calc_pvt`](@ref); they are

--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -30,7 +30,7 @@ const SPEEDOFLIGHT = 299792458.0
 # The GPS CNAV family (CNAV on L5/L2C, CNAV-2 on L1C): both broadcast the full week
 # number (no 1024-week rollover) and a quasi-Keplerian ephemeris (A_REF + ΔA,
 # Ω̇_REF + ΔΩ̇, …) rather than LNAV's directly-broadcast Keplerian elements — so
-# `orbital_elements` and the full-week `get_week` dispatch on this union.
+# `orbital_terms` and the full-week `get_week` dispatch on this union.
 const GPSModernNavData = Union{GNSSDecoder.GPSCNAVData,GNSSDecoder.GPSL1C_DData}
 
 """
@@ -562,7 +562,15 @@ function calc_pvt(
     healthy_states = view(states, healthy_indices)
     num_sats = length(healthy_states)
 
-    times = map(calc_corrected_time, healthy_states)
+    # One concrete [`ClockModel`](@ref) (with its [`Ephemeris`](@ref)) extraction per
+    # satellite, shared by the clock correction, the orbit propagation and the
+    # clock-drift lookup below. This is the Union{Nothing,…}-field → Float64 function
+    # barrier that keeps all the Kepler math allocation-free; it also gives the
+    # downstream maps a concrete element type even when `states` is heterogeneous
+    # (mixed constellations).
+    clock_models = map(state -> ClockModel(state.decoder, state.system), healthy_states)
+
+    times = map(calc_corrected_time, healthy_states, clock_models)
 
     # Classify each satellite by the GNSSSignals keys that drive the solution.
     # `get_time_system` (`GPST()`/`GST()`) groups the receiver clock bias — one per time
@@ -582,8 +590,8 @@ function calc_pvt(
 
     # Propagating the ephemerides.
     sat_positions_and_velocities = map(
-        (state, time) -> calc_satellite_position_and_velocity(state.decoder, time),
-        healthy_states,
+        (clock, time) -> calc_satellite_position_and_velocity(clock.ephemeris, time),
+        clock_models,
         times,
     )
     sat_positions = map(get_sat_position, sat_positions_and_velocities)
@@ -674,7 +682,7 @@ function calc_pvt(
     end
     H = calc_H(sat_positions_mat, ξ, bias_columns)
     user_velocity_and_clock_drift = calc_user_velocity_and_clock_drift(
-        sat_positions_and_velocities, healthy_states, times, H)
+        sat_positions_and_velocities, healthy_states, clock_models, times, H)
     position = ECEF(ξ[1], ξ[2], ξ[3])
     velocity = ECEF(
         user_velocity_and_clock_drift[1],
@@ -810,6 +818,9 @@ function get_LLA(pvt::PVTSolution)
     LLAfromECEF(wgs84)(pvt.position)
 end
 
+# `ephemeris.jl` first: the `Ephemeris` struct appears in method signatures of the
+# files that follow.
+include("ephemeris.jl")
 include("user_position.jl")
 include("sat_time.jl")
 include("sat_position.jl")

--- a/src/ephemeris.jl
+++ b/src/ephemeris.jl
@@ -1,0 +1,172 @@
+"""
+    Ephemeris
+
+Concrete (`Float64`-only) snapshot of one satellite's decoded broadcast orbit — the
+Keplerian elements, their perturbation corrections and the propagation constants —
+extracted once from a `GNSSDecoderState` and then used by the orbit kernels
+([`calc_satellite_position_and_velocity`](@ref), `calc_eccentric_anomaly`,
+`calc_relativistic_correction`). The broadcast clock model lives in the companion
+[`ClockModel`](@ref), which composes an `Ephemeris` (the relativistic clock term is
+orbit-dependent); a decoder whose clock is not (yet) decoded can still be propagated.
+
+The decoder's data fields are all `Union{Nothing, T}` (they fill in as the navigation
+message decodes), and the Kepler propagation reads ~20 of them in long arithmetic
+chains — too many small unions for the compiler to split, so every intermediate gets
+boxed. Extracting the fields into this concrete struct behind a function barrier makes
+the downstream math allocation-free and several times faster; `calc_pvt` performs the
+extraction once per satellite per solve.
+
+The two broadcast ephemeris parameterisations are normalised at extraction (see
+[`orbital_terms`](@ref)): the directly-broadcast Keplerian elements (GPS LNAV, Galileo
+I/NAV, F/NAV) and the quasi-Keplerian CNAV/CNAV-2 deltas both reduce to a semi-major
+axis `A` (+ rate `A_dot`), a mean motion `n_0` at the reference epoch (+ half-rate
+`n_dot_half`, zero for the directly-broadcast case) and an effective `Ω_dot`, so a
+single set of kernels serves all four navigation messages. The propagation constants
+(Earth rotation rate `Ω_dot_e`, relativistic `F`) are copied from the decoder so the
+kernels need only this struct.
+
+Constructing from a decoder that has not decoded all the orbit fields throws an
+`ArgumentError`; the fields required are a subset of the ones guaranteed by
+`is_decoding_completed_for_positioning`.
+"""
+struct Ephemeris
+    t_0e::Float64
+    A::Float64
+    sqrt_A::Float64
+    A_dot::Float64
+    n_0::Float64
+    n_dot_half::Float64
+    e::Float64
+    M_0::Float64
+    ω::Float64
+    i_0::Float64
+    i_dot::Float64
+    Ω_0::Float64
+    Ω_dot::Float64
+    C_us::Float64
+    C_uc::Float64
+    C_rs::Float64
+    C_rc::Float64
+    C_is::Float64
+    C_ic::Float64
+    Ω_dot_e::Float64
+    F::Float64
+end
+
+function Ephemeris(decoder::GNSSDecoder.GNSSDecoderState)
+    data = decoder.data
+    constants = decoder.constants
+    orb = orbital_terms(data, constants.μ)
+    # `something` doubles as the Union{Nothing,T} → T function barrier: each argument
+    # is concretely inferred (so nothing is boxed) and a missing field throws instead
+    # of poisoning the arithmetic downstream.
+    Ephemeris(
+        Float64(something(data.t_0e)),
+        orb.A,
+        orb.sqrt_A,
+        orb.A_dot,
+        orb.n_0,
+        orb.n_dot_half,
+        something(data.e),
+        something(data.M_0),
+        something(data.ω),
+        something(data.i_0),
+        something(data.i_dot),
+        something(data.Ω_0),
+        orb.Ω_dot,
+        something(data.C_us),
+        something(data.C_uc),
+        something(data.C_rs),
+        something(data.C_rc),
+        something(data.C_is),
+        something(data.C_ic),
+        constants.Ω_dot_e,
+        constants.F,
+    )
+end
+
+"""
+    ClockModel
+
+Concrete snapshot of one satellite's broadcast clock correction: the clock polynomial
+(`a_f0`, `a_f1`, `a_f2` at `t_0c`), the signal-dependent group delay folded into the
+constant `group_delay` (seconds, subtracted from the clock correction), and the
+[`Ephemeris`](@ref) the relativistic clock term is computed from. Used by the clock
+kernels (`correct_clock`, `calc_satellite_clock_drift`, `calc_corrected_time`);
+`calc_pvt` extracts one per satellite per solve and reuses its `ephemeris` for the
+orbit propagation, so the `Union{Nothing, …}` decoder fields are read exactly once
+(see [`Ephemeris`](@ref) for why that matters).
+"""
+struct ClockModel
+    ephemeris::Ephemeris
+    a_f0::Float64
+    a_f1::Float64
+    a_f2::Float64
+    t_0c::Float64
+    group_delay::Float64
+end
+
+# `correct_by_group_delay(decoder, system, Δt)` computes `Δt - group_delay` (with the
+# per-message/per-signal dispatch and missing-term handling), so evaluating it at zero
+# recovers the constant. Reusing it keeps this extraction and the directly-tested
+# group-delay logic a single source of truth.
+function ClockModel(decoder::GNSSDecoder.GNSSDecoderState, system::AbstractGNSSSignal)
+    data = decoder.data
+    ClockModel(
+        Ephemeris(decoder),
+        something(data.a_f0),
+        something(data.a_f1),
+        something(data.a_f2),
+        Float64(something(data.t_0c)),
+        -correct_by_group_delay(decoder, system, 0.0),
+    )
+end
+
+"""
+    orbital_terms(data, μ) -> (; A, sqrt_A, A_dot, n_0, n_dot_half, Ω_dot)
+
+Normalise the Keplerian terms that differ between the directly-broadcast ephemerides
+(GPS LNAV `GPSL1CAData`, Galileo I/NAV `GalileoE1BData` / F/NAV `GalileoE5aData`) and
+the quasi-Keplerian GPS CNAV/CNAV-2 ephemerides (`GPSCNAVData` for L5 and L2C,
+`GPSL1C_DData` for L1C):
+
+- `A`: semi-major axis at `t_0e` (m); `sqrt_A²` for the directly-broadcast case,
+  `A_REF + ΔA` for CNAV/CNAV-2
+- `sqrt_A`: its square root (m^½); the broadcast `sqrt_A` directly (no round-trip)
+  for the directly-broadcast case, `√A` for CNAV/CNAV-2 (which carry no `sqrt_A`)
+- `A_dot`: its rate (m/s; `0` for the directly-broadcast case)
+- `n_0`: mean motion at `t_0e` (rad/s), including the broadcast correction
+  (`Δn` / `Δn_0`)
+- `n_dot_half`: half the mean-motion rate `½ Δṅ_0` (rad/s²; `0` for the
+  directly-broadcast case), so the mean motion at time-from-ephemeris `t_k` is
+  `n_0 + n_dot_half · t_k` for every message type
+- `Ω_dot`: effective rate of right ascension (rad/s); broadcast directly, or
+  `Ω̇_REF + ΔΩ̇` for CNAV/CNAV-2
+"""
+function orbital_terms(data::GNSSDecoder.AbstractGNSSData, μ)
+    sqrt_A = something(data.sqrt_A)
+    (
+        A = sqrt_A^2,
+        sqrt_A = sqrt_A,
+        A_dot = 0.0,
+        n_0 = sqrt(μ) / sqrt_A^3 + something(data.Δn),
+        n_dot_half = 0.0,
+        Ω_dot = something(data.Ω_dot),
+    )
+end
+function orbital_terms(data::GPSModernNavData, μ)
+    # Quasi-Keplerian reference values from the CNAV user algorithm (IS-GPS-200N;
+    # identical in IS-GPS-705J and IS-GPS-800J); the broadcast fields are deltas off
+    # these.
+    A_REF = 26_559_710.0        # m
+    Ω_dot_REF = -2.6e-9 * π     # rad/s (-2.6e-9 semicircles/s)
+    A = A_REF + something(data.ΔA)
+    (
+        A = A,
+        sqrt_A = sqrt(A),
+        A_dot = something(data.A_dot),
+        n_0 = sqrt(μ / A^3) + something(data.Δn_0),
+        n_dot_half = 0.5 * something(data.Δn_0_dot),
+        Ω_dot = Ω_dot_REF + something(data.ΔΩ_dot),
+    )
+end

--- a/src/sat_position.jl
+++ b/src/sat_position.jl
@@ -1,39 +1,3 @@
-"""
-    orbital_elements(data, μ, t_k) -> (; A, sqrt_A, A_dot, n, Ω_dot)
-
-The Keplerian elements that differ between the directly-broadcast ephemerides
-(GPS LNAV `GPSL1CAData`, Galileo I/NAV `GalileoE1BData`) and the quasi-Keplerian
-GPS CNAV/CNAV-2 ephemerides (`GPSCNAVData` for L5 and L2C, `GPSL1C_DData` for
-L1C), evaluated at the time-from-ephemeris `t_k` (seconds):
-
-- `A`: semi-major axis at `t_0e` (m)
-- `sqrt_A`: its square root (m^½); the broadcast `sqrt_A` for the directly-broadcast
-  Keplerian case (no round-trip), `√A` for CNAV/CNAV-2 (which carry no `sqrt_A` field)
-- `A_dot`: its rate (m/s; `0` for the directly-broadcast Keplerian case)
-- `n`: corrected mean motion at `t_k` (rad/s)
-- `Ω_dot`: rate of right ascension (rad/s)
-
-Everything else the propagator needs (`e`, `ω`, `i_0`, `i_dot`, `M_0`, the `C_*`
-harmonic coefficients, `t_0e`) is named identically across all four nav messages
-and read from `data` directly. CNAV recovers `A` from `A_REF + ΔA` (with `Ȧ·t_k`
-added for the radius), the mean motion from `Δn_0 (+ ½ Δṅ_0 t_k)`, and `Ω̇` from
-`Ω̇_REF + ΔΩ̇`.
-"""
-function orbital_elements(data::GNSSDecoder.AbstractGNSSData, μ, t_k)
-    (A = data.sqrt_A^2, sqrt_A = data.sqrt_A, A_dot = 0.0, n = sqrt(μ) / data.sqrt_A^3 + data.Δn, Ω_dot = data.Ω_dot)
-end
-function orbital_elements(data::GPSModernNavData, μ, t_k)
-    # Quasi-Keplerian reference values from the CNAV user algorithm (IS-GPS-200N;
-    # identical in IS-GPS-705J and IS-GPS-800J); the broadcast fields are deltas off
-    # these.
-    A_REF = 26_559_710.0        # m
-    Ω_dot_REF = -2.6e-9 * π     # rad/s (-2.6e-9 semicircles/s)
-    A = A_REF + data.ΔA
-    n = sqrt(μ / A^3) + data.Δn_0 + 0.5 * data.Δn_0_dot * t_k
-    Ω_dot = Ω_dot_REF + data.ΔΩ_dot
-    (A = A, sqrt_A = sqrt(A), A_dot = data.A_dot, n = n, Ω_dot = Ω_dot)
-end
-
 function calc_eccentric_anomaly(mean_anomaly, eccentricity)
     Ek = mean_anomaly
     for k = 1:30
@@ -46,13 +10,15 @@ function calc_eccentric_anomaly(mean_anomaly, eccentricity)
     return Ek
 end
 
-function calc_eccentric_anomaly(decoder::GNSSDecoder.GNSSDecoderState, t)
-    data = decoder.data
-    time_from_ephemeris_reference_epoch = correct_week_crossovers(t - data.t_0e)
-    el = orbital_elements(data, decoder.constants.μ, time_from_ephemeris_reference_epoch)
-    mean_anomaly = data.M_0 + el.n * time_from_ephemeris_reference_epoch
-    calc_eccentric_anomaly(mean_anomaly, data.e)
+function calc_eccentric_anomaly(eph::Ephemeris, t)
+    time_from_ephemeris_reference_epoch = correct_week_crossovers(t - eph.t_0e)
+    n = eph.n_0 + eph.n_dot_half * time_from_ephemeris_reference_epoch
+    mean_anomaly = eph.M_0 + n * time_from_ephemeris_reference_epoch
+    calc_eccentric_anomaly(mean_anomaly, eph.e)
 end
+
+calc_eccentric_anomaly(decoder::GNSSDecoder.GNSSDecoderState, t) =
+    calc_eccentric_anomaly(Ephemeris(decoder), t)
 
 """
     calc_satellite_position(decoder::GNSSDecoder.GNSSDecoderState, t)
@@ -78,6 +44,7 @@ end
 
 """
     calc_satellite_position_and_velocity(decoder::GNSSDecoder.GNSSDecoderState, t)
+    calc_satellite_position_and_velocity(eph::Ephemeris, t)
     calc_satellite_position_and_velocity(state::SatelliteState)
 
 Calculate the satellite ECEF position and velocity from orbital parameters at time `t`.
@@ -87,6 +54,8 @@ for argument of latitude, radius, and inclination) to propagate the satellite ep
 
 # Arguments
 - `decoder`: GNSS decoder state containing ephemeris data
+- `eph`: An already-extracted [`Ephemeris`](@ref) — the form `calc_pvt` uses to reuse
+  one extraction per satellite across the clock and position kernels
 - `t`: Transmission time in system time (seconds)
 - `state`: A [`SatelliteState`](@ref) combining decoder, system, and phase measurements
 
@@ -94,65 +63,63 @@ for argument of latitude, radius, and inclination) to propagate the satellite ep
 A named tuple `(position, velocity)` where each is an `SVector{3, Float64}` in ECEF
 coordinates (meters and m/s respectively).
 """
-function calc_satellite_position_and_velocity(decoder::GNSSDecoder.GNSSDecoderState, t)
-    data = decoder.data
-    constants = decoder.constants
-    time_from_ephemeris_reference_epoch = correct_week_crossovers(t - data.t_0e)
-    el = orbital_elements(data, constants.μ, time_from_ephemeris_reference_epoch)
+function calc_satellite_position_and_velocity(eph::Ephemeris, t)
+    time_from_ephemeris_reference_epoch = correct_week_crossovers(t - eph.t_0e)
     # Semi-major axis at t_k: constant for LNAV/Galileo (A_dot = 0), `A_0 + Ȧ·t_k`
-    # for CNAV/CNAV-2.
-    semi_major_axis = el.A + el.A_dot * time_from_ephemeris_reference_epoch
-    corrected_mean_motion = el.n
-    eccentric_anomaly = calc_eccentric_anomaly(decoder, t)
-    eccentric_anomaly_dot = corrected_mean_motion / (1.0 - data.e * cos(eccentric_anomaly))
-    β = data.e / (1 + sqrt(1 - data.e^2))
+    # for CNAV/CNAV-2; same for the mean motion and its rate `n_dot_half`.
+    semi_major_axis = eph.A + eph.A_dot * time_from_ephemeris_reference_epoch
+    corrected_mean_motion = eph.n_0 + eph.n_dot_half * time_from_ephemeris_reference_epoch
+    mean_anomaly = eph.M_0 + corrected_mean_motion * time_from_ephemeris_reference_epoch
+    eccentric_anomaly = calc_eccentric_anomaly(mean_anomaly, eph.e)
+    eccentric_anomaly_dot = corrected_mean_motion / (1.0 - eph.e * cos(eccentric_anomaly))
+    β = eph.e / (1 + sqrt(1 - eph.e^2))
     true_anomaly =
         eccentric_anomaly +
         2 * atan(β * sin(eccentric_anomaly) / (1 - β * cos(eccentric_anomaly)))
     true_anomaly_dot =
         sin(eccentric_anomaly) *
         eccentric_anomaly_dot *
-        (1.0 + data.e * cos(true_anomaly)) /
-        (sin(true_anomaly) * (1.0 - data.e * cos(eccentric_anomaly)))
-    argument_of_latitude = true_anomaly + data.ω
+        (1.0 + eph.e * cos(true_anomaly)) /
+        (sin(true_anomaly) * (1.0 - eph.e * cos(eccentric_anomaly)))
+    argument_of_latitude = true_anomaly + eph.ω
     argrument_of_latitude_correction =
-        data.C_us * sin(2 * argument_of_latitude) +
-        data.C_uc * cos(2 * argument_of_latitude)
+        eph.C_us * sin(2 * argument_of_latitude) +
+        eph.C_uc * cos(2 * argument_of_latitude)
     radius_correction =
-        data.C_rs * sin(2 * argument_of_latitude) +
-        data.C_rc * cos(2 * argument_of_latitude)
+        eph.C_rs * sin(2 * argument_of_latitude) +
+        eph.C_rc * cos(2 * argument_of_latitude)
     inclination_correction =
-        data.C_is * sin(2 * argument_of_latitude) +
-        data.C_ic * cos(2 * argument_of_latitude)
+        eph.C_is * sin(2 * argument_of_latitude) +
+        eph.C_ic * cos(2 * argument_of_latitude)
     corrected_argument_of_latitude = argument_of_latitude + argrument_of_latitude_correction
     corrected_radius =
-        semi_major_axis * (1 - data.e * cos(eccentric_anomaly)) + radius_correction
+        semi_major_axis * (1 - eph.e * cos(eccentric_anomaly)) + radius_correction
     corrected_inclination =
-        data.i_0 + inclination_correction + data.i_dot * time_from_ephemeris_reference_epoch
+        eph.i_0 + inclination_correction + eph.i_dot * time_from_ephemeris_reference_epoch
 
     corrected_argument_of_latitude_dot =
         true_anomaly_dot +
         2 *
         (
-            data.C_us * cos(2 * corrected_argument_of_latitude) -
-            data.C_uc * sin(2 * corrected_argument_of_latitude)
+            eph.C_us * cos(2 * corrected_argument_of_latitude) -
+            eph.C_uc * sin(2 * corrected_argument_of_latitude)
         ) *
         true_anomaly_dot
     corrected_radius_dot =
-        el.A_dot * (1.0 - data.e * cos(eccentric_anomaly)) +
-        semi_major_axis * data.e * sin(eccentric_anomaly) * corrected_mean_motion /
-        (1.0 - data.e * cos(eccentric_anomaly)) +
+        eph.A_dot * (1.0 - eph.e * cos(eccentric_anomaly)) +
+        semi_major_axis * eph.e * sin(eccentric_anomaly) * corrected_mean_motion /
+        (1.0 - eph.e * cos(eccentric_anomaly)) +
         2 *
         (
-            data.C_rs * cos(2 * corrected_argument_of_latitude) -
-            data.C_rc * sin(2 * corrected_argument_of_latitude)
+            eph.C_rs * cos(2 * corrected_argument_of_latitude) -
+            eph.C_rc * sin(2 * corrected_argument_of_latitude)
         ) *
         true_anomaly_dot
     corrected_inclination_dot =
-        data.i_dot +
+        eph.i_dot +
         (
-            data.C_is * cos(2 * corrected_argument_of_latitude) -
-            data.C_ic * sin(2 * corrected_argument_of_latitude)
+            eph.C_is * cos(2 * corrected_argument_of_latitude) -
+            eph.C_ic * sin(2 * corrected_argument_of_latitude)
         ) *
         2 *
         true_anomaly_dot
@@ -168,10 +135,10 @@ function calc_satellite_position_and_velocity(decoder::GNSSDecoder.GNSSDecoderSt
         x_position_in_orbital_plane * corrected_argument_of_latitude_dot
 
     corrected_longitude_of_ascending_node =
-        data.Ω_0 + (el.Ω_dot - constants.Ω_dot_e) * time_from_ephemeris_reference_epoch -
-        constants.Ω_dot_e * data.t_0e
+        eph.Ω_0 + (eph.Ω_dot - eph.Ω_dot_e) * time_from_ephemeris_reference_epoch -
+        eph.Ω_dot_e * eph.t_0e
 
-    corrected_longitude_of_ascending_node_dot = el.Ω_dot - constants.Ω_dot_e
+    corrected_longitude_of_ascending_node_dot = eph.Ω_dot - eph.Ω_dot_e
 
     position = SVector(
         x_position_in_orbital_plane * cos(corrected_longitude_of_ascending_node) -
@@ -220,13 +187,17 @@ function calc_satellite_position_and_velocity(decoder::GNSSDecoder.GNSSDecoderSt
     (position = position, velocity = velocity)
 end
 
+calc_satellite_position_and_velocity(decoder::GNSSDecoder.GNSSDecoderState, t) =
+    calc_satellite_position_and_velocity(Ephemeris(decoder), t)
+
 function calc_satellite_position(state::SatelliteState)
     pos_and_vel = calc_satellite_position_and_velocity(state)
     pos_and_vel.position
 end
 function calc_satellite_position_and_velocity(state::SatelliteState)
-    t = calc_corrected_time(state)
-    calc_satellite_position_and_velocity(state.decoder, t)
+    clock = ClockModel(state.decoder, state.system)
+    t = calc_corrected_time(state, clock)
+    calc_satellite_position_and_velocity(clock.ephemeris, t)
 end
 
 function calc_pseudo_ranges(times)

--- a/src/sat_time.jl
+++ b/src/sat_time.jl
@@ -38,25 +38,27 @@ function calc_uncorrected_time(state::SatelliteState)
     t_tow + t_bits + t_code_phase + t_carrier_phase
 end
 
-function calc_relativistic_correction(decoder::GNSSDecoder.GNSSDecoderState, t)
-    data = decoder.data
-    time_from_ephemeris_reference_epoch = correct_week_crossovers(t - data.t_0e)
-    # √A from the effective elements: the broadcast `sqrt_A` directly for LNAV/Galileo,
-    # `√(A_REF + ΔA)` for CNAV/CNAV-2 (which carry no `sqrt_A` field).
-    el = orbital_elements(data, decoder.constants.μ, time_from_ephemeris_reference_epoch)
-    E = calc_eccentric_anomaly(decoder, t)
-    decoder.constants.F * data.e * el.sqrt_A * sin(E)
+# √A from the effective elements: the broadcast `sqrt_A` directly for LNAV/Galileo,
+# `√(A_REF + ΔA)` for CNAV/CNAV-2 (which carry no `sqrt_A` field).
+function calc_relativistic_correction(eph::Ephemeris, t)
+    E = calc_eccentric_anomaly(eph, t)
+    eph.F * eph.e * eph.sqrt_A * sin(E)
+end
+calc_relativistic_correction(decoder::GNSSDecoder.GNSSDecoderState, t) =
+    calc_relativistic_correction(Ephemeris(decoder), t)
+
+# The signal's group delay is already folded into `clock.group_delay` (see
+# [`ClockModel`](@ref)), so the correction is applied as a plain constant here.
+function correct_clock(clock::ClockModel, t)
+    Δtr = calc_relativistic_correction(clock.ephemeris, t)
+    Δt = clock.a_f0 + clock.a_f1 * (t - clock.t_0c) + clock.a_f2 * (t - clock.t_0c)^2 + Δtr
+    t - (Δt - clock.group_delay)
 end
 
-function correct_clock(decoder::GNSSDecoder.GNSSDecoderState, system, t)
-    Δtr = calc_relativistic_correction(decoder, t)
-    Δt =
-        decoder.data.a_f0 +
-        decoder.data.a_f1 * (t - decoder.data.t_0c) +
-        decoder.data.a_f2 * (t - decoder.data.t_0c)^2 +
-        Δtr
-    t - correct_by_group_delay(decoder, system, Δt)
-end
+correct_clock(decoder::GNSSDecoder.GNSSDecoderState, system, t) =
+    correct_clock(ClockModel(decoder, system), t)
+
+calc_satellite_clock_drift(clock::ClockModel, t) = clock.a_f1 + clock.a_f2 * t * 2
 
 function calc_satellite_clock_drift(decoder::GNSSDecoder.GNSSDecoderState, t)
     decoder.data.a_f1 +
@@ -147,9 +149,14 @@ correct_by_group_delay(
     t,
 ) = t - decoder.data.broadcast_group_delay_e1_e5a
 
-function calc_corrected_time(state::SatelliteState)
+calc_corrected_time(state::SatelliteState) =
+    calc_corrected_time(state, ClockModel(state.decoder, state.system))
+
+# The two-argument form lets `calc_pvt` reuse its per-satellite [`ClockModel`](@ref)
+# extraction instead of re-extracting per call.
+function calc_corrected_time(state::SatelliteState, clock::ClockModel)
     approximated_time = calc_uncorrected_time(state)
-    correct_clock(state.decoder, state.system, approximated_time)
+    correct_clock(clock, approximated_time)
 end
 
 """

--- a/src/user_position.jl
+++ b/src/user_position.jl
@@ -231,7 +231,13 @@ drift of the inter-system time offset (e.g. the GGTO rate `A_1G`), which is
 every satellite constrain the four unknowns instead of spending a column per
 system.
 """
-function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states, times, H)
+function calc_user_velocity_and_clock_drift(
+    sat_positions_and_velocities,
+    states,
+    clock_models,
+    times,
+    H,
+)
     num_sats = length(states)
     # Normal-equations form of the 4-unknown velocity + clock-drift least squares.
     # The velocity design row is [eₓ e_y e_z 1]: the line-of-sight unit vector (H's
@@ -248,7 +254,7 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states
         sat_pv = sat_positions_and_velocities[j]
         λ = SPEEDOFLIGHT / upreferred(get_center_frequency(state.system) / Hz)
         doppler = upreferred(state.carrier_doppler / Hz)
-        clock_drift = calc_satellite_clock_drift(state.decoder, times[j])
+        clock_drift = calc_satellite_clock_drift(clock_models[j], times[j])
         # Line-of-sight unit vector, already computed for the position solve and
         # stored in H's first three columns (calc_H) — no need to recompute calc_e.
         e = SVector{3}(view(H, j, 1:3))


### PR DESCRIPTION
## Problem

Every navigation-data field on a `GNSSDecoderState`'s `data` is `Union{Nothing, T}` (fields fill in as the message decodes). The Kepler propagation and clock correction read ~20 of them in long arithmetic chains — too many small unions for the compiler to split — so every intermediate gets boxed. Measured on the benchmark fixtures, this was over half of `calc_pvt`'s runtime and roughly 70% of its allocations.

## Change

Extract the fields once per satellite per solve into concrete `Float64` structs behind a function barrier (`src/ephemeris.jl`):

- **`Ephemeris`** — the broadcast orbit plus propagation constants. The directly-broadcast Keplerian (LNAV / I/NAV / F/NAV) and quasi-Keplerian CNAV/CNAV-2 parameterisations are normalised at extraction by `orbital_terms` (replacing `orbital_elements`), so one set of kernels serves all four navigation messages.
- **`ClockModel`** — the clock polynomial, the ranging-signal group delay folded to a constant via the existing (directly-tested) `correct_by_group_delay` dispatch, and the `Ephemeris` the relativistic term is computed from.

All orbit and clock kernels now run on these, allocation-free and **bit-identical** to before. The decoder-taking public API is unchanged (thin extraction wrappers), and a decoder with a complete orbit but not-yet-decoded clock can still be propagated (the `test/cnav.jl` self-consistency tests exercise exactly that, which is why orbit and clock are separate structs).

## Results

`calc_pvt` on the benchmark fixtures (median, same machine):

| Case | Before | After |
|---|---|---|
| 9 GPS sats, warm | 18.6 µs / 21.7 KiB / 622 allocs | **11.3 µs / 14.5 KiB / 183 allocs** |
| 9 GPS sats, cold | 31.5 µs / 31.5 KiB / 780 allocs | **24.7 µs / 24.3 KiB / 341 allocs** |
| 5 Galileo sats, warm | 10.7 µs / 15.9 KiB / 422 allocs | **6.8 µs / 11.9 KiB / 179 allocs** |

Full test suite passes; docs build cleanly (the new internals are documented on the API page).

## Relation to a possible GNSSDecoder refactor

Longer-term, GNSSDecoder could publish concrete ephemeris/clock substructs itself at `validate_data` promotion time (nullable at the top, concrete inside), which would let the extraction layer here shrink to a thin adapter or disappear — see the companion GNSSDecoder issue. The kernel rewrites in this PR carry over unchanged in that scenario, so merging this now doesn't conflict with that direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)