### PR TITLE
build(deps): allow Tracking 4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ LinearAlgebra = "1"
 LsqFit = "0.12, 0.13, 0.14, 0.15, 0.16"
 StaticArrays = "1"
 Test = "1"
-Tracking = "3"
+Tracking = "3, 4"
 Unitful = "1"
 julia = "1.10"
 


### PR DESCRIPTION
## What

Widen the `Tracking` compat bound to `"3, 4"` so PositionVelocityTime can be used with Tracking.jl v4 while remaining installable against Tracking 3.

## Why

Tracking.jl 4.0.0 overhauls the Doppler-estimator API — `TrackedSignal` drops `is_integration_completed` and gains a per-chunk `correlator_outputs` buffer, custom `AbstractDopplerEstimator`s now fold over those outputs, and a bare `downconvert_and_correlate(!)` consumes the whole sample buffer.

PVT consumes Tracking **only** through the weakdep extension `PositionVelocityTimeTrackingExt`, which uses just the stable `TrackedSat` getters (`get_code_phase` / `get_carrier_doppler` / `get_carrier_phase`). None of those changed across 3 → 4, so the compat bump is the only change required. This mirrors the earlier `build(deps): allow Tracking 3`.

## Validation

Proven end-to-end: with this change dev'd in, GNSSReceiver's ION RTL-SDR integration test computes a real PVT fix through `PositionVelocityTimeTrackingExt` on Tracking 4.1.0 (11 satellites, valid ECEF fix), on both `ComplexF32` and `Complex{Int16}` backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)