### PR TITLE
build(release): 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# [4.1.0](https://github.com/JuliaGNSS/PositionVelocityTime.jl/compare/v4.0.1...v4.1.0) (2026-07-26)
+
+
+### Features
+
+* support Tracking 4 ([d35afec](https://github.com/JuliaGNSS/PositionVelocityTime.jl/commit/d35afec))
+
 ## [4.0.1](https://github.com/JuliaGNSS/PositionVelocityTime.jl/compare/v4.0.0...v4.0.1) (2026-07-07)
 
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PositionVelocityTime"
 uuid = "52ec0b5e-ee36-11ea-211c-3d844fc5682d"
-version = "4.0.1"
+version = "4.1.0"
 authors = ["Soeren Schoenbrod <soeren.schoenbrod@nav.rwth-aachen.de>", "Michael Niestroj <michael.niestroj@rwth-aachen.de>", "Erik Deinzer <erik.deinzer@rwth-aachen.de>"]
 
 [deps]


### PR DESCRIPTION
Manual release commit for the Tracking 4 support merged in #55.

`semantic-release` does not bump on `build(deps):` commits (the `allow Tracking 4` merge produced *no release* — "Analysis complete: no release"), so the version bump is made by hand, mirroring the `build(release): 3.1.0` precedent for Tracking 3.

## Changes
- `Project.toml`: `version = "4.0.1"` → `"4.1.0"` (minor — widening the Tracking compat to `"3, 4"` is a backwards-compatible addition of support)
- `CHANGELOG.md`: add the 4.1.0 entry

## After merge
Registration is handled separately by the maintainer (tag `v4.1.0` + `@JuliaRegistrator register`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)