### PR TITLE
fix: reject degenerate PVT geometries instead of throwing

### DIFF
--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -348,11 +348,14 @@ the per-band inter-frequency-bias columns from [`band_ifb_layout`](@ref) — and
 known per-satellite range offsets. Returns `nothing` when the constellation cannot be
 solved. The decision is observability-driven, not merely count-driven:
 
-- When the coverage graph is connected and `n ≥ 3 + num_systems + num_ifb`, estimate
-  everything independently: the inter-system offset and the receiver inter-frequency
-  biases are observed directly from the geometry, so neither inherits the broadcast-GGTO
-  error (the satellite group delays are already removed per satellite upstream, so the
-  per-band column carries the receiver chain).
+- When the coverage graph is connected and the satellites suffice for the unknowns
+  (`n ≥ 3 + num_systems + num_ifb` measurements, of which `3 + num_systems` must come
+  from *distinct* satellites — extra bands of an already-tracked satellite add
+  inter-frequency-bias information, not geometry), estimate everything independently: the
+  inter-system offset and the receiver inter-frequency biases are observed directly from
+  the geometry, so neither inherits the broadcast-GGTO error (the satellite group delays
+  are already removed per satellite upstream, so the per-band column carries the receiver
+  chain).
 - Otherwise merge the Galileo clock onto GPS via the broadcast GGTO when a Galileo
   satellite carries it. This removes a clock unknown (the scarce-satellite case) and
   reconnects a disjoint GPS/Galileo band split (the disconnected case — where a band's
@@ -367,13 +370,29 @@ solved. The decision is observability-driven, not merely count-driven:
   only the bias decomposition is ambiguous. Else return `nothing`.
 
 Because `band_ifb_layout` never creates an unobservable IFB column, every returned
-layout yields a full-rank design matrix — the degenerate disjoint-band case is removed
-structurally, not caught after the fact.
+layout is structurally sound — the degenerate disjoint-band case is removed by
+construction, not caught after the fact. The satellite conditions above are structural
+too, and thus necessary but not sufficient: a returned layout can still have degenerate
+*geometry* (lines of sight that span too little), which no satellite count can see. That
+is left to the checks `calc_pvt` makes on the solved geometry — the DOP's positive-definite
+test and the velocity solve's own — rather than pre-screened.
 """
 function decide_bias_layout(states, systems, bands, times)
     num_sats = length(states)
+    # Distinct physical satellites, identified by `(time system, PRN)` — a PRN is only
+    # unique within its GNSS. A satellite tracked on several frequency bands appears once
+    # per band in `states` but supplies a single line of sight, its repeats differing from
+    # it solely in an inter-frequency-bias column. Only distinct satellites can therefore
+    # constrain the geometry and clock unknowns, while the inter-frequency biases live on
+    # the repeats — hence the two conditions in `enough_satellites` below.
+    num_distinct_sats = length(unique(zip(systems, (state.decoder.prn for state in states))))
+    # Both are necessary for a full-rank design (`H` has `3 + M + B` columns, and its rows
+    # take only `num_distinct_sats` distinct values outside the IFB columns), neither is
+    # sufficient: the geometry itself can still be degenerate, which `calc_pvt` screens
+    # for once the design matrix exists.
     enough_satellites(layout) =
-        num_sats >= 3 + layout.num_clock_biases + length(layout.extra_bands)
+        num_sats >= 3 + layout.num_clock_biases + length(layout.extra_bands) &&
+        num_distinct_sats >= 3 + layout.num_clock_biases
 
     function bias_layout_for(effective_systems)
         unique_effective = unique(effective_systems)
@@ -491,9 +510,12 @@ band beyond a reference band (shared across constellations on that band; see
 extra bands. Position and time are found by least squares; velocity and clock drift
 are solved from carrier Doppler.
 
-A solution requires `n ≥ 3 + M + B` healthy satellites (each system needs at least
-one satellite, and a system contributing a single satellite spends it entirely
-on that system's clock bias). When that condition fails but both GPS and Galileo
+A solution requires `n ≥ 3 + M + B` healthy satellite measurements (each system needs at
+least one satellite, and a system contributing a single satellite spends it entirely
+on that system's clock bias), of which `3 + M` must come from *distinct* satellites: a
+satellite tracked on several bands supplies one line of sight, and its extra
+measurements constrain the inter-frequency biases rather than the geometry. When either
+condition fails but both GPS and Galileo
 are present and the Galileo message carries the GGTO (Galileo–GPS Time Offset),
 the Galileo clock bias is collapsed onto GPS using the broadcast offset, which
 makes a 4-satellite GPS+Galileo fix possible. Estimating an independent bias is
@@ -536,9 +558,11 @@ See [`tropospheric_delay`](@ref).
 
 # Returns
 A [`PVTSolution`](@ref) containing position, velocity, time, DOP values, and
-satellite information. Returns `prev_pvt` if too few healthy satellites are
-available to solve the constellation (including the GGTO fallback) or if the
-GDOP is negative.
+satellite information. Returns `prev_pvt` if the epoch cannot be solved: too few healthy
+satellites to solve the constellation (including the GGTO fallback and the
+distinct-satellite condition — a satellite tracked on several bands supplies one line of
+sight, so measurements alone are not enough), a geometry whose solved design matrix is
+rank deficient (reported as a negative GDOP).
 
 # Throws
 - `ArgumentError`: If fewer than 4 satellite states are provided
@@ -645,6 +669,7 @@ function calc_pvt(
     # entirely and the solve runs on the raw pseudoranges.
     correct_atmosphere =
         !isnothing(ionospheric_correction) || enable_tropospheric_correction
+
     ξ, residuals = if iszero(prev_ξ)
         # Cold start: no prior position, and the Klobuchar model is undefined near
         # the geocenter, so first obtain an approximate fix from an uncorrected
@@ -673,9 +698,21 @@ function calc_pvt(
         user_position(sat_positions_mat, corrected_ranges, bias_columns, prev_ξ)
     end
     H = calc_H(sat_positions_mat, ξ, bias_columns)
+    position = ECEF(ξ[1], ξ[2], ξ[3])
+
+    # Check the geometry at the converged position — the DOP is reported to the caller, and
+    # a rank deficiency here (negative GDOP) means `ξ` is meaningless, so nothing should be
+    # derived from it. The satellite conditions in `decide_bias_layout` already reject the
+    # count-shaped degeneracies before the solve; this catches what a count cannot see.
+    #
+    # This check must stay ahead of the velocity solve: it is what makes that solve's
+    # normal-equations matrix positive definite (see `calc_user_velocity_and_clock_drift`),
+    # and with the order reversed a degenerate geometry throws `SingularException` there.
+    dop = calc_DOP(H, position, primary_clock_index)
+    dop.GDOP < 0 && return prev_pvt
+
     user_velocity_and_clock_drift = calc_user_velocity_and_clock_drift(
         sat_positions_and_velocities, healthy_states, times, H)
-    position = ECEF(ξ[1], ξ[2], ξ[3])
     velocity = ECEF(
         user_velocity_and_clock_drift[1],
         user_velocity_and_clock_drift[2],
@@ -698,11 +735,6 @@ function calc_pvt(
     )
 
     sat_infos = SatInfo.(sat_positions, times, residuals .* m)
-
-    dop = calc_DOP(H, position, primary_clock_index)
-    if dop.GDOP < 0
-        return prev_pvt
-    end
 
     # Inter-system biases relative to the reference (primary) system's clock, in
     # meters. The reference is omitted (its bias is `time_correction`); for a

--- a/src/user_position.jl
+++ b/src/user_position.jl
@@ -118,6 +118,43 @@ function calc_Avv!(dir_deriv, sat_positions, ξ, v)
 end
 
 """
+    positive_definite_cholesky(A::Symmetric) -> Union{Cholesky,Nothing}
+
+Cholesky factorization of `A`, or `nothing` when `A` is not positive definite to within
+the rank tolerance below. Used to solve and invert the normal-equations matrices of this
+package (`HᵀH` for a design matrix `H`), which are positive definite exactly when `H`
+has full column rank — so `nothing` means the geometry left some parameter
+unobservable, and the epoch cannot be solved.
+
+Cholesky is the right factorization for a symmetric positive definite matrix (≈2×
+cheaper than a general or symmetric-indefinite one, and numerically faithful), and
+`check = false` reports the non-positive-definite case instead of throwing. `issuccess`
+alone is not a sufficient test, for two reasons:
+
+  - StaticArrays accepts a pivot of exactly zero (its check is `pivot ≥ 0`) and returns
+    a "successful" factor whose diagonal contains that zero — the triangular solve that
+    follows then throws the very `SingularException` this is meant to avoid.
+  - A rank-deficient design usually does not produce an exactly zero pivot at all:
+    rounding leaves a tiny positive one instead, and the factorization "succeeds" with a
+    solution made of rounding noise (velocities of 1e8 m/s and the like).
+
+Both are caught by a relative rank tolerance on the Cholesky diagonal, which for a
+normal-equations matrix is on the scale of `H`'s singular values — so its
+smallest-to-largest ratio is ~`1/cond(H)`. A rank-deficient design leaves the ratio at
+rounding level (~1e-8 for `Float64`, or exactly 0), whereas even a barely usable GNSS
+geometry stays above ~1e-3; `cbrt(eps)` ≈ 6e-6 sits between the two with orders of
+magnitude of margin either way. The test costs a few comparisons and does not allocate.
+
+$SIGNATURES
+"""
+function positive_definite_cholesky(A::Symmetric)
+    F = cholesky(A; check = false)
+    issuccess(F) || return nothing
+    pivots = diag(F.U)
+    minimum(pivots) > cbrt(eps(eltype(pivots))) * maximum(pivots) ? F : nothing
+end
+
+"""
 Calculates the dilution of precision for a given geometry matrix H
 
 `H_GEO` has `3 + num_clock_biases + num_ifb` columns (three position partials, one per
@@ -130,8 +167,8 @@ by the rotation). `GDOP` spans all parameters; `TDOP` reports the clock variance
 primary (reference) system — see [`PVTSolution`](@ref) — while the other systems' clock
 (inter-system-bias) and the inter-frequency-bias variances enter `GDOP` only.
 
-A rank-deficient geometry makes `HᵀH` singular (not positive definite); a
-non-throwing Cholesky detects this and the function returns the sentinel
+A rank-deficient geometry makes `HᵀH` singular (not positive definite);
+[`positive_definite_cholesky`](@ref) detects this and the function returns the sentinel
 `DOP(-1, …)` instead of erroring.
 
 $SIGNATURES
@@ -140,14 +177,12 @@ $SIGNATURES
 `primary_clock_index`: Index (1…num_clock_biases) of the clock column whose variance is reported as TDOP
 """
 function calc_DOP(H_GEO, user_pos::ECEF, primary_clock_index = 1)
-    # HᵀH is symmetric positive definite iff H has full column rank. Cholesky is
-    # the right factorization for an SPD matrix (≈2× cheaper than a general or
-    # symmetric-indefinite inverse, and numerically faithful), and `check = false`
-    # lets a rank-deficient (singular) geometry fail gracefully via `issuccess`
-    # instead of throwing. The inverse of an SPD matrix is itself SPD, so the DOP
-    # variances on the diagonal are then guaranteed non-negative.
-    F = cholesky(Symmetric(H_GEO' * H_GEO); check = false)
-    issuccess(F) || return DOP(-1, -1, -1, -1, -1)
+    # HᵀH is symmetric positive definite iff H has full column rank, so a
+    # rank-deficient (singular) geometry fails gracefully here instead of throwing —
+    # see `positive_definite_cholesky`. The inverse of an SPD matrix is itself SPD, so
+    # the DOP variances on the diagonal are then guaranteed non-negative.
+    F = positive_definite_cholesky(Symmetric(H_GEO' * H_GEO))
+    isnothing(F) && return DOP(-1, -1, -1, -1, -1)
     D = inv(F)
 
     # Rotate the ECEF position covariance into the local ENU (East, North, Up)
@@ -230,6 +265,9 @@ drift of the inter-system time offset (e.g. the GGTO rate `A_1G`), which is
 ~1e-6 m/s — far below the Doppler velocity resolution. Using one common drift lets
 every satellite constrain the four unknowns instead of spending a column per
 system.
+
+Requires a geometry whose position design `H` has full column rank — the caller
+establishes that with [`calc_DOP`](@ref) before calling this; see the comment at the solve.
 """
 function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states, times, H)
     num_sats = length(states)
@@ -257,7 +295,17 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states
         HtH += a * a'
         Hty += a * yⱼ
     end
-    HtH \ Hty
+    # `HtH` is positive definite whenever the position design `H` has full column rank,
+    # which `calc_pvt` has established via `calc_DOP` before calling this: writing the
+    # velocity design as `A = H·T` — `T` keeps H's three position columns, sums its clock
+    # columns into the drift column and drops the IFB columns — `T` has orthogonal columns
+    # of norms 1, 1, 1, √M, so `null(T) = {0}` and a full-rank `H` gives a full-rank `A`
+    # (with `cond(A) ≤ √M·cond(H)`). Hence a plain Cholesky solve, no rank test of its own.
+    #
+    # This is why `calc_pvt` must keep the DOP check *ahead* of this call: with the order
+    # reversed, a rank-deficient geometry reaches the solve below and throws
+    # `SingularException` — the failure this arrangement exists to prevent.
+    cholesky(Symmetric(HtH)) \ Hty
 end
 
 get_sat_position(x) = x.position

--- a/test/inter_frequency_bias.jl
+++ b/test/inter_frequency_bias.jl
@@ -70,6 +70,24 @@
             carrier_doppler = 0.0Hz, carrier_phase = 0.0)
     end
 
+    # GPS L5 (CNAV) copy of a GPS L1 C/A satellite — the L2C copy above on the L5 band:
+    # the same CNAV message type, with the L5 group delay (ISC_L5I5 = 0) and L5 health
+    # in place of the L2 ones. Only used to build a third band.
+    function as_l5i(state)
+        l2c = as_l2c(state)
+        d = l2c.decoder.data
+        l5_data = GNSSDecoder.GPSCNAVData(;
+            (f => getfield(d, f) for f in fieldnames(GNSSDecoder.GPSCNAVData))...,
+            ISC_L2C = nothing, l2_health = nothing, ISC_L5I5 = 0.0, l5_health = false)
+        target = PositionVelocityTime.calc_uncorrected_time(state)
+        num_bits, code_phase = bits_and_code_phase(GPSL5I(), l5_data.TOW, target)
+        dec = GNSSDecoder.GNSSDecoderState(GNSSDecoder.GPSL5IDecoderState(state.decoder.prn);
+            data = l5_data, raw_data = l5_data,
+            num_bits_after_valid_syncro_sequence = num_bits)
+        SatelliteState(; decoder = dec, system = GPSL5I(), code_phase = code_phase,
+            carrier_doppler = 0.0Hz, carrier_phase = 0.0)
+    end
+
     @testset "user_position recovers per-band IFB and per-system clocks" begin
         user = ECEFfromLLA(wgs84)(LLA(50.1, 8.7, 120.0))
         ecef_from_enu = ECEFfromENU(user, wgs84)
@@ -137,17 +155,32 @@
         @test ifb4 == [0, 0, 1, 1, 0, 0]
     end
 
-    @testset "layout count gate accounts for the extra band" begin
-        # GPS-only (no GGTO collapse possible), dummy states: 3 position + 1 clock +
-        # num_ifb unknowns. The decoder is only touched on the GGTO path, never reached
-        # for a GPS-only constellation, so plain integers stand in for the states.
+    @testset "layout gate counts both measurements and distinct satellites" begin
+        # GPS-only (no GGTO collapse possible): 3 position + 1 clock + num_ifb unknowns.
+        # Beyond the PRN of each state, the decoder is touched only on the GGTO path,
+        # never reached for a GPS-only constellation, so PRN-carrying stand-ins suffice.
         decide = PositionVelocityTime.decide_bias_layout
-        # Dual-band GPS ⇒ 1 IFB ⇒ needs 5 satellites; 4 is too few.
-        @test decide(collect(1:5), fill(GPST(), 5), [:L1, :L5, :L1, :L5, :L1], zeros(5)) !==
-              nothing
-        @test decide(collect(1:4), fill(GPST(), 4), [:L1, :L5, :L1, :L5], zeros(4)) === nothing
+        gate(prns, bands) = decide([(; decoder = (; prn = prn)) for prn in prns],
+            fill(GPST(), length(prns)), bands, zeros(length(prns)))
+
+        # Dual-band GPS ⇒ 1 IFB ⇒ needs 5 measurements; 4 is too few.
+        @test gate(1:5, [:L1, :L5, :L1, :L5, :L1]) !== nothing
+        @test gate(1:4, [:L1, :L5, :L1, :L5]) === nothing
         # Single-band GPS ⇒ no IFB ⇒ 4 satellites suffice.
-        @test decide(collect(1:4), fill(GPST(), 4), fill(:L1, 4), zeros(4)) !== nothing
+        @test gate(1:4, fill(:L1, 4)) !== nothing
+
+        # The measurement count alone is not enough. Only distinct satellites can
+        # constrain the 3 position + 1 clock unknowns, because the extra bands of an
+        # already-tracked satellite repeat its line of sight: two satellites on three
+        # bands (6 ≥ 3 + 1 + 2) and three satellites on two bands (6 ≥ 3 + 1 + 1) both
+        # clear the measurement count while remaining unsolvable.
+        @test gate([1, 1, 1, 2, 2, 2], [:L1, :L2, :L5, :L1, :L2, :L5]) === nothing
+        @test gate([1, 1, 2, 2, 3, 3], [:L1, :L5, :L1, :L5, :L1, :L5]) === nothing
+        # Four distinct satellites on two bands clear both conditions, and so does the
+        # leanest dual-frequency constellation: four satellites on L1, one of them also
+        # tracked on L5 — that repeat is what makes the IFB observable.
+        @test gate([1, 1, 2, 2, 3, 3, 4, 4], repeat([:L1, :L5], 4)) !== nothing
+        @test gate([1, 2, 3, 4, 1], [:L1, :L1, :L1, :L1, :L5]) !== nothing
     end
 
     @testset "single-band fix reports no inter-frequency bias" begin
@@ -258,5 +291,34 @@
         @test abs(pvt_ggto.inter_frequency_biases[:L5].value) < 5m
         @test isfinite(pvt_ggto.dop.GDOP) && 0 < pvt_ggto.dop.GDOP < 1e4
         @test norm(pvt_ggto.position - connected.position) < 10
+    end
+
+    # Regression, end to end through calc_pvt: two real satellites tracked on three bands
+    # clear the measurement count (6 ≥ 3 + 1 clock + 2 IFB) with two lines of sight, so
+    # the design matrix is rank deficient and the epoch is unsolvable. calc_pvt must skip
+    # it (return `prev_pvt`) rather than throw — while the layout gate still counted
+    # measurements only, the epoch reached the solve and its cold-start step, which is
+    # undamped and factorises HᵀH directly, threw SingularException out of LsqFit.
+    @testset "unsolvable triple-band geometry is skipped, not thrown" begin
+        gps = gps_l1_states(0.0Hz)
+        two = gps[1:2]
+        states = [two; map(as_l2c, two); map(as_l5i, two)]
+        systems = map(state -> GNSSSignals.get_time_system(state.system), states)
+        bands = map(state -> GNSSSignals.get_band_id(state.system), states)
+        times = map(PositionVelocityTime.calc_corrected_time, states)
+        # All six measurements are usable and clear the measurement count, and it is the
+        # distinct-satellite condition — two satellites for 3 + 1 unknowns — that rejects
+        # the constellation as unsolvable.
+        @test all(PositionVelocityTime.is_sat_healthy(state.decoder) for state in states)
+        @test bands == [:L1, :L1, :L2, :L2, :L5, :L5]
+        @test length(states) >= 3 + 1 + 2
+        @test PositionVelocityTime.decide_bias_layout(states, systems, bands, times) ===
+              nothing
+
+        ref = calc_pvt(gps; kw...)                      # L1-only GPS fix, as previous PVT
+        @test calc_pvt(states, ref; kw...) === ref      # warm start: previous fix kept
+        cold = calc_pvt(states; kw...)                  # cold start: nothing to fall back on
+        @test isempty(cold.sats)
+        @test iszero(cold.position)
     end
 end

--- a/test/pvt.jl
+++ b/test/pvt.jl
@@ -74,8 +74,9 @@ function with_ggto(state; A_0G, A_1G = 0.0, t_0G = 0, WN_0G = 0)
     )
 end
 
-# Relabels a SatelliteState's decoder PRN. The PRN is not used in the solve, only
-# as the `sats`-dict key, so this isolates the (system, PRN) keying behaviour.
+# Relabels a SatelliteState's decoder PRN. Nothing in the least-squares solve depends on
+# the PRN — it identifies a satellite, as the `sats`-dict key and for the layout's
+# distinct-satellite count — so this isolates that identity from the measurements.
 function with_prn(state, prn)
     d = state.decoder
     new_decoder = GNSSDecoder.GNSSDecoderState(;
@@ -184,6 +185,15 @@ end
     @test pvt.reference_system == GPST()
     @test Set(keys(pvt.inter_system_biases)) == Set([GST()])
 
+    # A satellite is identified as (time system, PRN) for the layout's
+    # distinct-satellite count, not by PRN alone: a Galileo satellite sharing a GPS PRN
+    # is still the fourth distinct satellite the collapsed layout needs, so relabelling
+    # it leaves the fix untouched (PRN-only identity would count three and bail).
+    collided = with_prn(with_ggto(gal[1]; A_0G = Δ), gps[1].decoder.prn)
+    pvt_collided = calc_pvt([gps[1:3]; [collided]]; approximate_year = 2021,
+        enable_ionospheric_correction = false, enable_tropospheric_correction = false)
+    @test pvt_collided.position == pvt.position
+
     # A single Galileo satellite carrying the GGTO is enough to collapse the
     # whole Galileo set: here only the first of two Galileo satellites has it.
     @test !PositionVelocityTime.ggto_available(gal[2].decoder)
@@ -275,4 +285,87 @@ end
     @test cog(10.0, 0.0, 7.0) ≈ cog(10.0, 0.0, 0.0)
     # Always wrapped to [0, 360)°.
     @test 0° ≤ cog(-3.0, -4.0, 0.0) < 360°
+end
+
+# Regression: a degenerate geometry must be reported, not thrown out of a least-squares
+# solve as a SingularException. Observed while processing a dual-band recording, where an
+# epoch's geometry left the velocity normal equations singular and the 4×4 solve threw
+# before the epoch could be rejected.
+@testset "degenerate geometry is rejected without throwing" begin
+    @testset "positive_definite_cholesky rejects what is not positive definite" begin
+        pdc = PositionVelocityTime.positive_definite_cholesky
+        @test !isnothing(pdc(Symmetric([2.0 0.0; 0.0 3.0])))     # positive definite
+        @test isnothing(pdc(Symmetric([1.0 1.0; 1.0 1.0])))      # semidefinite: zero pivot
+        @test isnothing(pdc(Symmetric([1.0 0.0; 0.0 -1.0])))     # indefinite
+        # Ill-conditioned to the point of being rank deficient in Float64: the pivot is
+        # positive, so `issuccess` alone would accept it and return rounding noise.
+        @test isnothing(pdc(Symmetric([1.0 0.0; 0.0 1e-14])))
+        # A poor but genuinely solvable geometry is still accepted (cond(HᵀH) = 1e6).
+        @test !isnothing(pdc(Symmetric([1.0 0.0; 0.0 1e-6])))
+    end
+
+    @testset "the geometry checks follow the design matrix rank" begin
+        # `calc_DOP` and the velocity solve both decide rank through the normal-equations
+        # matrix, so that is what these cases exercise.
+        full_rank(H) = !isnothing(
+            PositionVelocityTime.positive_definite_cholesky(Symmetric(H' * H)))
+        @test full_rank([1.0 0.0 1.0; 0.0 1.0 1.0; 1.0 1.0 0.0])
+        @test !full_rank(repeat([1.0 0.0 1.0], 3))               # identical rows
+        # A single-band, single-system position design over three satellites: four
+        # columns constrained by three lines of sight is always rank deficient — the shape
+        # the layout's distinct-satellite condition rejects before the solve.
+        @test !full_rank([1.0 0.0 0.0 1.0; 0.0 1.0 0.0 1.0; 0.0 0.0 1.0 1.0])
+
+        # The case no satellite count can see: four *distinct* satellites — plenty for the
+        # 3 + 1 unknowns — whose lines of sight lie on a common cone (equal projection onto
+        # z), which puts the clock column in their span.
+        c = 0.5
+        s = sqrt(1 - c^2)
+        cone = [s 0.0 c; 0.0 s c; -s 0.0 c; 0.0 -s c]
+        @test !full_rank([cone ones(4)])
+        # Tilting one satellite off the cone restores full rank.
+        tilted = [cone[1:3, :]; normalize([0.0, -s, 2c])']
+        @test full_rank([tilted ones(4)])
+    end
+
+    # The velocity solve assumes a full-rank position design (its caller establishes that
+    # with `calc_DOP` first), so what is pinned here is the implication it relies on: a
+    # degenerate line-of-sight set is degenerate for the velocity design too, and would
+    # reach a singular solve if the DOP check were ever moved after it.
+    @testset "a degenerate line-of-sight set is degenerate for the velocity design" begin
+        states = gps_l1_states(0.0Hz)[1:4]
+        times = map(PositionVelocityTime.calc_corrected_time, states)
+        sat_pvs = map(
+            (state, time) ->
+                PositionVelocityTime.calc_satellite_position_and_velocity(state.decoder, time),
+            states,
+            times,
+        )
+        # Only H's first three columns — the line-of-sight unit vectors — are read; the
+        # per-system clock columns are collapsed into a single drift column internally,
+        # so one trailing column of ones stands in for them here.
+        design(dirs) = reduce(vcat, [[normalize(d)' 1.0] for d in dirs])
+        velocity_and_drift(dirs) = PositionVelocityTime.calc_user_velocity_and_clock_drift(
+            sat_pvs, states, times, design(dirs))
+
+        # Four well-spread directions ⇒ solvable: a finite [vx, vy, vz, ċ].
+        solution = velocity_and_drift(
+            [[1.0, 0.2, 0.9], [-0.5, 1.0, 0.7], [0.3, -1.0, 0.5], [0.0, 0.1, 1.0]])
+        @test length(solution) == 4
+        @test all(isfinite, solution)
+
+        # The degenerate cases are stated on the design matrix, since the solve itself no
+        # longer tests rank. Two distinct directions (a satellite tracked on a second band
+        # repeats its line of sight) leave the position columns rank deficient.
+        solvable(dirs) = !isnothing(PositionVelocityTime.positive_definite_cholesky(
+            Symmetric(design(dirs)' * design(dirs))))
+        @test !solvable([[1.0, 0.2, 0.9], [1.0, 0.2, 0.9], [0.3, -1.0, 0.5], [0.3, -1.0, 0.5]])
+
+        # Three independent directions on a common cone (equal projection onto z) put the
+        # drift column in their span, leaving the fourth pivot exactly zero — the shape
+        # that produced SingularException(4) from the 4×4 solve.
+        c = 0.5
+        s = sqrt(1 - c^2)
+        @test !solvable([[s, 0.0, c], [0.0, s, c], [-s, 0.0, c], [0.0, -s, c]])
+    end
 end


### PR DESCRIPTION
# fix: reject degenerate PVT geometries instead of throwing

## The bug

Processing the TEX-CUP recording with GNSSReceiver raised `SingularException(4)` from the
4×4 velocity + clock-drift solve in `calc_user_velocity_and_clock_drift`. The epoch's
geometry was rank deficient, and that solve ran *before* `calc_DOP` could reject it, so an
unsolvable epoch crashed the receiver instead of being skipped.

## Why a satellite count could not catch it

`decide_bias_layout` gated solvability on a measurement count, `n ≥ 3 + M + B`. But the
extra bands of an already-tracked satellite repeat its line of sight: they constrain the
inter-frequency biases and never the 3 position + M clock unknowns. Three satellites spread
over two or three bands therefore satisfy the count with five to seven measurements while
supplying only three lines of sight — the position design is rank deficient, its
clock-drift column falls in the span of the position columns, and the 4×4 solve dies on its
fourth pivot (hence `info = 4`).

## The change

Three parts, in the order `calc_pvt` decides:

1. **`decide_bias_layout` additionally requires `3 + M` *distinct* satellites**, identified
   as `(time system, PRN)` — a PRN is only unique within its GNSS. This is the condition
   that rejects the count-shaped degeneracies, before any solve runs.
2. **The DOP check moved ahead of the velocity solve.** The ordering now carries the
   guarantee rather than a second rank test: writing the velocity design as `A = H·T` (where
   `T` keeps H's three position columns, sums its M clock columns into the drift column and
   drops the B IFB columns), `T` has orthogonal columns of norms 1, 1, 1, √M, so
   `null(T) = {0}` and a full-rank `H` gives a full-rank `A`, with `cond(A) ≤ √M·cond(H)`.
   The velocity solve is a plain Cholesky solve with a documented precondition.
3. **`calc_DOP`'s rank test goes through a new `positive_definite_cholesky`**, which applies
   a relative tolerance to the Cholesky diagonal. `issuccess` alone is not sufficient:
   StaticArrays' non-throwing Cholesky *accepts* a pivot of exactly zero and leaves the
   `SingularException` to the triangular solve that follows, and a rank-deficient design
   more often rounds to a tiny *positive* pivot, which "succeeds" and returns rounding
   noise (velocities of 1e8 m/s and the like).

## Validation on real data

The full 83-minute TEX-CUP rover recording (2019-05-09, NTLAB front end) was processed with
GNSSReceiver 3.1.0 — 4993 s, **49,542 PVT epochs at 10 Hz**, GPS L1 C/A + L2C + L5 and
Galileo E1B + E5a as data signals across three bands. Every epoch was solved twice on
identical satellite states: once by this branch, once by the released 4.1.0 source loaded as
a second module, so the comparison is exact and needs only one tracking pass (a separate
pre-fix run would stop at its first exception).

**The released code throws `SingularException(4)` on 9 epochs. Each has exactly 3 distinct
satellites, and the distinct-satellite condition rejects every one of them:**

| t [s] | healthy measurements | distinct satellites | bands |
|------:|---------------------:|--------------------:|-------|
| 1283.9 | 5 | 3 | L1, L5 |
| 1291.8 | 7 | 3 | L1, L2, L5 |
| 2491.3 | 6 | 3 | L1, L2, L5 |
| 3386.7 | 5 | 3 | L1, L5 |
| 3388.5 | 5 | 3 | L1, L5 |
| 3391.1 | 5 | 3 | L1, L5 |
| 3391.6 | 5 | 3 | L1, L5 |
| 3545.2 | 5 | 3 | L1, L5 |
| 3805.5 | 5 | 3 | L1, L5 |

At 1291.8 s, for instance, the healthy set is PRN 30 on L1/L2/L5 plus Galileo 11 and 24 on
E1/E5a: seven measurements, three satellites, three lines of sight. The released
measurement gate passes it (7 ≥ 3 + 1 clock + 2 IFB, after the GGTO collapse); the new
distinct-satellite condition does not (3 < 3 + 1).

Overall run quality with this branch: **93.0 % of epochs solved**, median 3-D error
**6.7 m** (p68 9.5 m, p95 62 m in the downtown segments), residual RMS 2.85 m, median GDOP
3.2, 15 satellites per fix (35 in open sky), CN0 median 41.6 dBHz. Estimated biases: L5
inter-frequency bias −3.1 m and Galileo−GPS inter-system bias −0.7 m, both physically
sensible. The geometry guards rejected 2563 epochs (5.2 %), concentrated in the urban
minutes and absent from open sky.

## Tests

New coverage in `test/pvt.jl` and `test/inter_frequency_bias.jl`:

- `positive_definite_cholesky` accepts a positive definite matrix, rejects semidefinite,
  indefinite, and numerically rank-deficient ones, and still accepts a poor but solvable
  geometry (`cond(HᵀH) = 1e6`).
- The degeneracy shapes on the design matrix: identical rows, a three-satellite
  single-band design, and four distinct satellites whose lines of sight lie on a common
  cone (the case no satellite count can see).
- The layout gate counts measurements *and* distinct satellites, with the leanest
  dual-frequency constellation (four satellites on L1, one also on L5) still accepted.
- Satellite identity is `(time system, PRN)`: a Galileo satellite relabelled onto a GPS
  PRN is still the fourth distinct satellite a GGTO-collapsed layout needs.
- End to end: two satellites tracked on three bands clear the measurement count with two
  lines of sight, and `calc_pvt` skips the epoch — warm and cold — instead of throwing.

## Notes for the reviewer

- `calc_pvt` gained no new failure mode: a rejected epoch returns `prev_pvt`, as it already
  did for a negative GDOP.
- Behaviour change worth knowing: epochs whose geometry is numerically rank deficient
  (`cond(H)` beyond ~1e6) now return `prev_pvt` rather than a fix built on rounding noise.
- The DOP check must stay ahead of the velocity solve; both sites carry a comment saying so,
  since reversing the order reintroduces the exception.
- Cost is unchanged (one `calc_H` per epoch, as before); warm `calc_pvt` measures ~69 µs on
  the GPS+Galileo fixtures.

## Out of scope, found while validating

Two issues seen on TEX-CUP that these guards deliberately do not address, both worth their
own investigation:

- **A tracking channel whose CN0 estimate goes to `Inf`** (t ≈ 1479–1507 s and 1801–1839 s,
  663 epochs): its measurement turns to garbage and the fix diverges by up to 1370 km while
  the geometry stays full rank (GDOP 2.8–4.0, 9–13 distinct satellites). PVT has no outlier
  screening, so no rank guard can catch it.
- **The estimated L2 inter-frequency bias is ≈ −150 m**, against −3.1 m for L5, which points
  at L2C group-delay/ISC handling rather than the RF chain. The IFB column absorbs it, so
  the position is unaffected.
