### PR TITLE
fix: skip unsolvable PVT epochs instead of throwing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ using Tracking
 sat_state = SatelliteState(decoder, tracking_result)
 ```
 
-For user position computation at least 4 decoded satellites must be provided. 
-
 ## Usage
 
 ### User position calculation
 The function 
 ```julia
-# You need at least 4 satellite states
-calc_PVT(sat_states)
+calc_pvt(sat_states)
 ``` 
-provides a complete position calculation.
+provides a complete position calculation. A fix needs at least 4 healthy, fully decoded
+satellites (more for a multi-GNSS or multi-band set); when the epoch cannot be solved,
+the previous solution is returned unchanged instead of an error, so a receiver can pass
+whatever it currently tracks.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,7 +45,7 @@ using Tracking
 sat_state = SatelliteState(decoder, gpsl1, sat_state)
 ```
 
-With at least 4 satellite states, compute the PVT solution:
+Compute the PVT solution:
 
 ```julia
 pvt = calc_pvt(sat_states)
@@ -57,3 +57,8 @@ references its broadcasts to its own system time, [`calc_pvt`](@ref) estimates o
 receiver clock bias per GNSS time system, so a combined fix needs at least `3 + M`
 satellites for `M` distinct systems. The per-system clock offsets are reported as
 `pvt.inter_system_biases` relative to `pvt.reference_system`.
+
+If too few healthy satellites are tracked to solve the constellation — or the geometry
+turns out to be degenerate — [`calc_pvt`](@ref) returns the `prev_pvt` it was given (the
+origin solution by default) rather than throwing, so a receiver can hand it whatever it
+currently tracks each epoch and carry the last solution forward.

--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -63,6 +63,34 @@ struct BiasColumns
 end
 
 """
+    BiasLayout
+
+How one epoch's estimated biases are laid out, as decided by
+[`decide_bias_layout`](@ref): the design-matrix columns, the bands its
+inter-frequency-bias columns belong to, and the source of the range offsets a
+GGTO-collapsed layout needs.
+
+# Fields
+- `bias_columns::BiasColumns`: the per-satellite column assignment (see
+  [`BiasColumns`](@ref)).
+- `extra_bands::Vector{Symbol}`: band of each inter-frequency-bias column, so
+  `extra_bands[i]` belongs to column `i` of the IFB block.
+- `reference_bands::Vector{Symbol}`: per IFB column, the reference band of its coverage
+  component — the anchor that column's bias is measured against (see
+  [`band_ifb_layout`](@ref)).
+- `ggto_decoder::Union{Nothing,GNSSDecoder.GNSSDecoderState}`: the Galileo decoder whose
+  broadcast GGTO converts the collapsed measurements (see
+  [`calc_ggto_range_offsets`](@ref)), or `nothing` for a layout that estimates every clock
+  bias independently. Declared as a union so one concrete `BiasLayout` covers both.
+"""
+struct BiasLayout
+    bias_columns::BiasColumns
+    extra_bands::Vector{Symbol}
+    reference_bands::Vector{Symbol}
+    ggto_decoder::Union{Nothing,GNSSDecoder.GNSSDecoderState}
+end
+
+"""
     num_lsq_params(bias_columns::BiasColumns) -> Int
 
 Length of the least-squares state vector for `bias_columns`:
@@ -340,13 +368,19 @@ function band_ifb_layout(systems, bands)
 end
 
 """
-    decide_bias_layout(states, systems, bands, times)
-        -> (bias_columns::BiasColumns, extra_bands, reference_bands, ggto_offsets)
+    decide_bias_layout(states, systems, bands) -> Union{BiasLayout,Nothing}
 
 Decide the full least-squares bias layout — one clock column per GNSS time system plus
-the per-band inter-frequency-bias columns from [`band_ifb_layout`](@ref) — and the
-known per-satellite range offsets. Returns `nothing` when the constellation cannot be
-solved. The decision is observability-driven, not merely count-driven:
+the per-band inter-frequency-bias columns from [`band_ifb_layout`](@ref) — and return it
+as a [`BiasLayout`](@ref), whose `ggto_decoder` also carries how a collapsed layout's
+measurements are converted. Returns `nothing` when the constellation cannot be solved.
+
+Every input is a classification of the epoch, never a transmit time: the counts, the
+coverage graph and `ggto_available` are all the decision needs. The offsets its
+`ggto_decoder` enables are built afterwards, once [`calc_pvt`](@ref) has the transmit
+times.
+
+The decision is observability-driven, not merely count-driven:
 
 - When the coverage graph is connected and the satellites suffice for the unknowns
   (`n ≥ 3 + num_systems + num_ifb` measurements, of which `3 + num_systems` must come
@@ -377,14 +411,12 @@ too, and thus necessary but not sufficient: a returned layout can still have deg
 is left to the checks `calc_pvt` makes on the solved geometry — the DOP's positive-definite
 test and the velocity solve's own — rather than pre-screened.
 """
-function decide_bias_layout(states, systems, bands, times)
+function decide_bias_layout(states, systems, bands)
     num_sats = length(states)
     # Distinct physical satellites, identified by `(time system, PRN)` — a PRN is only
-    # unique within its GNSS. A satellite tracked on several frequency bands appears once
-    # per band in `states` but supplies a single line of sight, its repeats differing from
-    # it solely in an inter-frequency-bias column. Only distinct satellites can therefore
-    # constrain the geometry and clock unknowns, while the inter-frequency biases live on
-    # the repeats — hence the two conditions in `enough_satellites` below.
+    # unique within its GNSS. A satellite tracked on several bands appears once per band in
+    # `states` but supplies one line of sight, so only distinct satellites constrain the
+    # geometry and clock unknowns; its repeats constrain the inter-frequency biases.
     num_distinct_sats = length(unique(zip(systems, (state.decoder.prn for state in states))))
     # Both are necessary for a full-rank design (`H` has `3 + M + B` columns, and its rows
     # take only `num_distinct_sats` distinct values outside the IFB columns), neither is
@@ -404,17 +436,17 @@ function decide_bias_layout(states, systems, bands, times)
             extra_bands, reference_bands, num_components)
     end
 
-    as_result(layout, ggto_offsets) = (
+    as_bias_layout(layout, ggto_decoder) = BiasLayout(
         BiasColumns(layout.clock_bias_indices, layout.num_clock_biases,
             layout.ifb_indices, length(layout.extra_bands)),
         layout.extra_bands,
         layout.reference_bands,
-        ggto_offsets,
+        ggto_decoder,
     )
 
     independent_layout = bias_layout_for(systems)
     if independent_layout.num_components == 1 && enough_satellites(independent_layout)
-        return as_result(independent_layout, zeros(num_sats))
+        return as_bias_layout(independent_layout, nothing)
     end
 
     # Connected-but-scarce or disconnected: try the GGTO collapse (merge Galileo onto
@@ -425,23 +457,40 @@ function decide_bias_layout(states, systems, bands, times)
     if (GPST() in systems) && !isnothing(ggto_idx)
         merged_layout = bias_layout_for(map(sys -> sys == GST() ? GPST() : sys, systems))
         if enough_satellites(merged_layout)
-            # Per the OS SIS ICD the GGTO is GST − GPST, so a Galileo transmit time
-            # becomes GPS time by SUBTRACTING it; the modeled range carries −c·GGTO and
-            # the solve yields inter_system_biases[GST()] = −c·(GST − GPST).
-            ggto_decoder = states[ggto_idx].decoder
-            ggto_offsets = zeros(num_sats)
-            for j in 1:num_sats
-                systems[j] == GST() || continue
-                ggto_offsets[j] = -SPEEDOFLIGHT * calc_ggto_offset(ggto_decoder, times[j])
-            end
-            return as_result(merged_layout, ggto_offsets)
+            return as_bias_layout(merged_layout, states[ggto_idx].decoder)
         end
     end
 
     # No collapse available. The independent layout is still observable (its IFBs are
     # component-restricted); use it if there are enough satellites, otherwise unsolvable.
     enough_satellites(independent_layout) ?
-    as_result(independent_layout, zeros(num_sats)) : nothing
+    as_bias_layout(independent_layout, nothing) : nothing
+end
+
+"""
+    calc_ggto_range_offsets(ggto_decoder, systems, times) -> Vector{Float64}
+
+Per-satellite range offsets (metres) that carry a GGTO collapse into the measurements, as
+decided by [`decide_bias_layout`](@ref): all-zero when `ggto_decoder === nothing` (every
+time system keeps its own clock unknown, so no measurement needs converting), and
+otherwise `−c · Δt_systems` for each Galileo satellite, evaluated at its own transmit
+time.
+
+Per the OS SIS ICD the GGTO is `Δt_systems = GST − GPST` (see
+[`calc_ggto_offset`](@ref)), so a Galileo transmit time becomes GPS time by SUBTRACTING
+it; the modeled range therefore carries `−c·GGTO`, and the solve yields
+`inter_system_biases[GST()] = −c·(GST − GPST)`. Which Galileo satellite reports the GGTO
+does not matter — it is one constellation-wide offset — so `decide_bias_layout` picks the
+first decoded copy and it converts every Galileo measurement.
+"""
+function calc_ggto_range_offsets(ggto_decoder, systems, times)
+    offsets = zeros(length(systems))
+    isnothing(ggto_decoder) && return offsets
+    for j in eachindex(systems)
+        systems[j] == GST() || continue
+        offsets[j] = -SPEEDOFLIGHT * calc_ggto_offset(ggto_decoder, times[j])
+    end
+    offsets
 end
 
 """
@@ -562,10 +611,8 @@ satellite information. Returns `prev_pvt` if the epoch cannot be solved: too few
 satellites to solve the constellation (including the GGTO fallback and the
 distinct-satellite condition — a satellite tracked on several bands supplies one line of
 sight, so measurements alone are not enough), a geometry whose solved design matrix is
-rank deficient (reported as a negative GDOP).
-
-# Throws
-- `ArgumentError`: If fewer than 4 satellite states are provided
+rank deficient (reported as a negative GDOP). None of these throw, so a receiver can pass
+whatever it currently tracks each epoch and carry `prev_pvt` forward.
 """
 function calc_pvt(
     states::AbstractVector{<:SatelliteState},
@@ -574,19 +621,14 @@ function calc_pvt(
     enable_ionospheric_correction::Bool = true,
     enable_tropospheric_correction::Bool = true,
 )
-    length(states) < 4 &&
-        throw(ArgumentError("You'll need at least 4 satellites to calculate PVT"))
     # Keep a satellite only if its full nav-data set is decoded and it reports healthy.
     # Checking completeness first guarantees the health bit has been decoded.
     healthy_indices = findall(
         x -> is_decoding_completed_for_positioning(x.decoder) && is_sat_healthy(x.decoder),
         states,
     )
-    length(healthy_indices) < 4 && return prev_pvt
     healthy_states = view(states, healthy_indices)
     num_sats = length(healthy_states)
-
-    times = map(calc_corrected_time, healthy_states)
 
     # Classify each satellite by the GNSSSignals keys that drive the solution.
     # `get_time_system` (`GPST()`/`GST()`) groups the receiver clock bias — one per time
@@ -599,10 +641,14 @@ function calc_pvt(
     systems = map(state -> get_time_system(state.system), healthy_states)
     bands = map(state -> get_band_id(state.system), healthy_states)
 
-    bias_layout = decide_bias_layout(healthy_states, systems, bands, times)
+    # Solvability is decided here. A degenerate geometry, which no count can see, is caught
+    # after the solve by the DOP.
+    bias_layout = decide_bias_layout(healthy_states, systems, bands)
     isnothing(bias_layout) && return prev_pvt
-    bias_columns, extra_bands, reference_bands, ggto_offsets = bias_layout
+    (; bias_columns, extra_bands, reference_bands, ggto_decoder) = bias_layout
     (; clock_bias_indices, num_clock_biases) = bias_columns
+
+    times = map(calc_corrected_time, healthy_states)
 
     # Propagating the ephemerides.
     sat_positions_and_velocities = map(
@@ -631,7 +677,8 @@ function calc_pvt(
     pseudo_ranges, reference_time = calc_pseudo_ranges(times)
     # Apply the known per-satellite GGTO time-system offset (zero unless Galileo was
     # collapsed onto GPS) as a measurement correction, like the atmospheric delays
-    # below.
+    # below. Kept for the inter-system-bias readout at the end.
+    ggto_offsets = calc_ggto_range_offsets(ggto_decoder, systems, times)
     pseudo_ranges = pseudo_ranges .- ggto_offsets
 
     # Seed each clock bias from the previous solution, reconstructing a system's

--- a/test/inter_frequency_bias.jl
+++ b/test/inter_frequency_bias.jl
@@ -161,7 +161,7 @@
         # never reached for a GPS-only constellation, so PRN-carrying stand-ins suffice.
         decide = PositionVelocityTime.decide_bias_layout
         gate(prns, bands) = decide([(; decoder = (; prn = prn)) for prn in prns],
-            fill(GPST(), length(prns)), bands, zeros(length(prns)))
+            fill(GPST(), length(prns)), bands)
 
         # Dual-band GPS ⇒ 1 IFB ⇒ needs 5 measurements; 4 is too few.
         @test gate(1:5, [:L1, :L5, :L1, :L5, :L1]) !== nothing
@@ -305,15 +305,13 @@
         states = [two; map(as_l2c, two); map(as_l5i, two)]
         systems = map(state -> GNSSSignals.get_time_system(state.system), states)
         bands = map(state -> GNSSSignals.get_band_id(state.system), states)
-        times = map(PositionVelocityTime.calc_corrected_time, states)
         # All six measurements are usable and clear the measurement count, and it is the
         # distinct-satellite condition — two satellites for 3 + 1 unknowns — that rejects
         # the constellation as unsolvable.
         @test all(PositionVelocityTime.is_sat_healthy(state.decoder) for state in states)
         @test bands == [:L1, :L1, :L2, :L2, :L5, :L5]
         @test length(states) >= 3 + 1 + 2
-        @test PositionVelocityTime.decide_bias_layout(states, systems, bands, times) ===
-              nothing
+        @test PositionVelocityTime.decide_bias_layout(states, systems, bands) === nothing
 
         ref = calc_pvt(gps; kw...)                      # L1-only GPS fix, as previous PVT
         @test calc_pvt(states, ref; kw...) === ref      # warm start: previous fix kept

--- a/test/pvt.jl
+++ b/test/pvt.jl
@@ -74,6 +74,27 @@ function with_ggto(state; A_0G, A_1G = 0.0, t_0G = 0, WN_0G = 0)
     )
 end
 
+# Marks a GPS L1 C/A SatelliteState's decoder unhealthy: the six health bits are the
+# subframe-1 SV health word, and a set MSB (nav data bad) is what `is_sat_healthy`
+# rejects. GNSSDecoder 3 renamed the field `svhealth` -> `sv_health`, as in
+# `fixtures.jl`'s `gps_l1ca_data`.
+function with_health_bad(state)
+    d = state.decoder
+    unhealthy(data) =
+        :sv_health in fieldnames(GNSSDecoder.GPSL1CAData) ?
+        GNSSDecoder.GPSL1CAData(data; sv_health = "100000") :
+        GNSSDecoder.GPSL1CAData(data; svhealth = "100000")
+    new_decoder = GNSSDecoder.GNSSDecoderState(
+        d; raw_data = unhealthy(d.raw_data), data = unhealthy(d.data))
+    SatelliteState(;
+        decoder = new_decoder,
+        system = state.system,
+        code_phase = state.code_phase,
+        carrier_doppler = state.carrier_doppler,
+        carrier_phase = state.carrier_phase,
+    )
+end
+
 # Relabels a SatelliteState's decoder PRN. Nothing in the least-squares solve depends on
 # the PRN — it identifies a satellite, as the `sats`-dict key and for the layout's
 # distinct-satellite count — so this isolates that identity from the measurements.
@@ -217,6 +238,20 @@ end
     @test PositionVelocityTime.ggto_available(g.decoder)
     @test !PositionVelocityTime.ggto_available(gal[1].decoder)
     @test !PositionVelocityTime.ggto_available(gps[1].decoder)
+
+    # calc_ggto_range_offsets turns the decoder `decide_bias_layout` selected into the
+    # per-satellite range corrections: −c·GGTO for the collapsed (Galileo) satellites at
+    # their own transmit times, zero for the anchor system's. An independent layout
+    # (`nothing`) needs no conversion at all.
+    offset_systems = [GPST(), GST(), GPST(), GST()]
+    offset_times = [100.0, 200.0, 300.0, 400.0]
+    offsets = PositionVelocityTime.calc_ggto_range_offsets(
+        g.decoder, offset_systems, offset_times)
+    @test offsets[[1, 3]] == [0.0, 0.0]
+    @test offsets[[2, 4]] ≈
+          [-C * PositionVelocityTime.calc_ggto_offset(g.decoder, t) for t in (200.0, 400.0)]
+    @test PositionVelocityTime.calc_ggto_range_offsets(
+        nothing, offset_systems, offset_times) == zeros(4)
 end
 
 @testset "PVT primary system is the most-populated GNSS" begin
@@ -285,6 +320,34 @@ end
     @test cog(10.0, 0.0, 7.0) ≈ cog(10.0, 0.0, 0.0)
     # Always wrapped to [0, 360)°.
     @test 0° ≤ cog(-3.0, -4.0, 0.0) < 360°
+end
+
+# Every unsolvable epoch takes the same exit — `prev_pvt`, never a throw — whether the
+# shortfall is in the raw satellite count, in how many of them are usable, or in the layout
+# the constellation demands.
+@testset "an unsolvable epoch returns prev_pvt instead of throwing" begin
+    kwargs = (; approximate_year = 2021, enable_ionospheric_correction = false,
+        enable_tropospheric_correction = false)
+    gps = gps_l1_states(0.0Hz)
+    reference = calc_pvt(gps; kwargs...)
+    @test reference.position != ECEF(0, 0, 0)
+
+    # Too few states to hold 3 position + 1 clock unknown, down to none at all: with no
+    # previous solution the default (origin) one comes back unchanged.
+    for n in 0:3
+        pvt = calc_pvt(gps[1:n]; kwargs...)
+        @test pvt.position == ECEF(0, 0, 0)
+        @test isnothing(pvt.time)
+        @test isempty(pvt.sats)
+        # Given a previous fix, that fix is what is carried forward.
+        @test calc_pvt(gps[1:n], reference; kwargs...) === reference
+    end
+
+    # An unhealthy satellite is dropped before the count is taken, so 4 states carrying
+    # only 3 usable ones exit exactly as 3 states do.
+    unhealthy = [gps[1:3]; [with_health_bad(gps[4])]]
+    @test length(unhealthy) == 4
+    @test calc_pvt(unhealthy, reference; kwargs...) === reference
 end
 
 # Regression: a degenerate geometry must be reported, not thrown out of a least-squares


### PR DESCRIPTION
## Summary

`calc_pvt` threw an `ArgumentError` for fewer than 4 satellite states, while every other
unsolvable epoch returned `prev_pvt`. Whether an epoch is solvable is a property of the
data, not of the call — a receiver stepping through a recording does not choose how many
satellites it currently tracks — so this makes the count-shaped case take the same exit as
all the others, and consolidates the two solvability checks that were left into one gate
that runs before any ephemeris work.

## Why the throw was the odd one out

- **Same situation, two control flows.** 3 tracked satellites threw; 4 tracked satellites
  of which one was unhealthy or not fully decoded returned `prev_pvt`. Callers had to both
  wrap the call in `try`/`catch` and test the returned solution.
- **The count was not the requirement.** Solvability is `n ≥ 3 + M + B` with `3 + M`
  *distinct* satellites, and every failure of that already returned `prev_pvt` — as does a
  rank-deficient geometry (#57, c83ff9a). The stricter condition was the graceful one: a
  5-satellite GPS+Galileo+L5 epoch that cannot be solved returned `prev_pvt`, a
  3-satellite GPS-only epoch threw.
- **It was redundant.** `healthy_indices` is a subset of `states`, so `length(states) < 4`
  already implied `length(healthy_indices) < 4`.

## One gate, before the ephemerides

Dropping the throw left two solvability checks in `calc_pvt`: a hardcoded count and the
layout decision. The constant restated layout knowledge (3 position plus the leanest
layout's single clock unknown) in the caller, where a future layout needing fewer clock
unknowns would silently make it too strict; and the layout decision ran only after the
transmit times had been computed, because it took `times` to build the GGTO offsets.

Nothing in the decision needs a transmit time — the satellite counts, the coverage graph
and `ggto_available` all read the classification only. So:

- `decide_bias_layout(states, systems, bands)` no longer takes `times`, and reports the
  Galileo decoder whose broadcast GGTO converts the collapsed measurements (`nothing` for
  an independent layout) instead of the finished offset vector.
- `calc_pvt` calls it directly after the health filter, with no count check of its own, and
  builds the offsets afterwards through the new `calc_ggto_range_offsets` — from the times
  the solve needs anyway, and next to the atmospheric corrections it belongs with.
- The layout comes back as a `BiasLayout` struct rather than a positional 4-tuple, so the
  call site reads fields by name. `ggto_decoder` is declared as a union, so both branches
  share one concrete type and the return type is `Union{BiasLayout,Nothing}` — a mixed
  GPS+Galileo constellation inferred a three-way union before.

One gate now covers every count-shaped rejection, including the ones the constant could not
see: three satellites over two bands clears `n ≥ 3 + M + B` with six measurements and is
rejected on the distinct-satellite condition.

## Compatibility

Callers passing 4 or more states are unaffected — same layouts, same offsets, same
solutions. The only caller that sees a difference is one relying on the exception as input
validation, and that contract was already unreliable, since 4 undecoded or unhealthy states
never raised it. Released as a patch: no signature, type or return-type change, and the
`< 4` input class now takes an exit that already existed for the equivalent case.

## Measurements

On the GPS L1 C/A / Galileo E1B fixtures (`@benchmark`, `min` of 2000 samples):

| epoch | before | after |
| --- | --- | --- |
| unsolvable, 3 GPS + 1 Galileo (4 states, needs 5 for two clock biases) | 12.8 µs, 306 allocs | **8.6 µs, 195 allocs** |
| solvable, 4 GPS | 12.2–12.5 µs, 427 allocs | 12.2–12.5 µs, 427 allocs |
| fewer than 4 states | 0.13 µs, 16 allocs | 0.77 µs, 80 allocs |

The first row is the transmit times no longer computed for a rejected epoch. Solvable
epochs are unchanged (the spread is run-to-run noise, allocation counts identical). The
last row is the cost of running the layout decision instead of a length comparison —
microseconds per second at 10 Hz, which is why the reorder is justified by having a single
gate rather than by the timings.

## Tests

Locally on Julia 1.12: `Pkg.test()` green, the opt-in L125 real-data integration test green
(8/8, `PVT_RUN_INTEGRATION_TEST=true`), and `docs/make.jl` builds clean. The 1.10 and macOS
matrix entries are left to CI.

New coverage:

- 0–3 states return the given `prev_pvt` unchanged (and the default origin solution when
  there is none), and 4 states with only 3 usable ones exit identically — the distinction
  the `ArgumentError` used to draw.
- `calc_ggto_range_offsets`: zeros for `nothing`, `−c·GGTO` at each Galileo satellite's own
  transmit time, zero for the anchor system's.
- The two direct `decide_bias_layout` call sites lose their dummy `times`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
