### PR TITLE
feat: support Tracking 5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ LinearAlgebra = "1"
 LsqFit = "0.12, 0.13, 0.14, 0.15, 0.16"
 StaticArrays = "1"
 Test = "1"
-Tracking = "3, 4"
+Tracking = "3, 4, 5"
 Unitful = "1"
 julia = "1.10"
 


### PR DESCRIPTION
Widens the `Tracking` compat bound to `"3, 4, 5"`.

## Why no source change is needed

PVT consumes Tracking only through the weakdep extension `PositionVelocityTimeTrackingExt` (the `TrackedSat` getters `get_code_phase` / `get_carrier_doppler` / `get_carrier_phase`) and, in the opt-in real-data integration test, through `TrackState`, `add_satellite!`, `track!`, `get_soft_bits` and `get_sat_state`. Every one of those is unchanged across 4 → 5:

| Tracking v5 breaking change | PVT impact |
| --- | --- |
| exported `get_bits` accessor removed | none — never used; the integration test already reads `get_soft_bits` and takes the sign |
| `BitBuffer` drops packed `buffer::UInt128` / `length` (positional ctor 11 → 9 args) | none — never constructed |
| `TrackedSignal` gains `last_fully_integrated_num_code_blocks` (positional ctor +1 arg) | none — never constructed |
| `estimate_cn0` divides by the record's real integration time, not one code period | none — never called |

The one semantic risk was checked explicitly: `reset(::BitBuffer)` calls `empty!(soft_bits)` in v5 exactly as in v4, so `get_soft_bits` still returns only the bits decoded by the last `track!` call, and the integration test's per-window `decode` loop stays correct.

`benchmark/Project.toml` and `docs/Project.toml` don't reference Tracking, so there are no other bounds to widen.

## Verification

Against Tracking **5.0.0** (5.1.0 is not registered yet; it is a pure feature release adding `get_last_fully_integrated_integration_time`):

- Full test suite passes.
- `test/pvt_integration.jl` is opt-in (`PVT_RUN_INTEGRATION_TEST`, a ~1.6 GB capture download) and stays skipped, so the suite alone only exercises the extension's getters. The tracking-loop chain that test drives was therefore additionally exercised end to end on a short synthetic GPS L1 C/A signal — acquire → grouped `TrackState` → `add_satellite!` from an `AcquisitionResults` → windowed `track!` → per-window `get_soft_bits` drain → `get_sat_state` → `SatelliteState` via the extension — recovering all 60 transmitted bits (up to the expected global polarity inversion).

## Note on GNSSDecoder

This does **not** depend on [JuliaRegistries/General#163342](https://github.com/JuliaRegistries/General/pull/163342) (GNSSDecoder v3.8.0). That release only widens a *test-only* compat bound — GNSSDecoder lists `Tracking` in `[extras]`/`[targets].test`, never in `[deps]` or `[weakdeps]`, and test-only compat never reaches the registry. PVT resolves Tracking 5.0.0 against the already-registered GNSSDecoder 3.7.0.

## Release typing

Typed `feat:` deliberately. The Tracking 4 bump (d35afec) landed as `build(deps):`, which semantic-release does not bump, and needed a manual release commit (9fc3120) to follow. Widening compat to allow a new major is a backwards-compatible addition of support → minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)