### PR TITLE
docs: fix stale API names in the README and docs quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,28 +16,31 @@ Calculates position and time by using GNSS data
 ### Install
 ```julia
 julia> ]
-pkg> PositionVelocityTime.jl
+pkg> add PositionVelocityTime
 ```
 
 Decoded data and code phase of satellite must be combined in the provided `SatelliteState` struct. 
 ```julia
 using PositionVelocityTime, GNSSSignals, GNSSDecoder
 # decode satellite
-gpsl1 = GPSL1()
+gpsl1 = GPSL1CA()
 sat_state = SatelliteState(
     decoder = decoder,
     system = gpsl1,
     code_phase = code_phase,
+    carrier_doppler = carrier_doppler,
     carrier_phase = carrier_phase # optional
 )
 ```
 The declaration of `carrier_phase` is optional due to its small effect on the user position.
 
-Alternatively, the tracking result can be passed to `SatelliteState` instead of `system`, `code_phase` and `carrier_phase`:
+Alternatively, a `Tracking.TrackedSat` can be passed to `SatelliteState` instead of
+`code_phase`, `carrier_doppler` and `carrier_phase` — `tracked_sat` below is what
+`Tracking.get_sat_state` returns for a tracked satellite:
 ```julia
 using Tracking
 # track and decode satellite
-sat_state = SatelliteState(decoder, tracking_result)
+sat_state = SatelliteState(decoder, gpsl1, tracked_sat)
 ```
 
 ## Usage

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,7 +28,7 @@ Decoded data and code phase of a satellite must be combined in the [`SatelliteSt
 ```julia
 using PositionVelocityTime, GNSSSignals, GNSSDecoder
 
-gpsl1 = GPSL1()
+gpsl1 = GPSL1CA()
 sat_state = SatelliteState(
     decoder = decoder,
     system = gpsl1,
@@ -38,11 +38,13 @@ sat_state = SatelliteState(
 )
 ```
 
-Alternatively, pass a `Tracking.SatState` directly:
+Alternatively, pass a `Tracking.TrackedSat` directly — `tracked_sat` is what
+`Tracking.get_sat_state` returns for a tracked satellite, and the code phase, carrier
+Doppler, and carrier phase are read off it:
 
 ```julia
 using Tracking
-sat_state = SatelliteState(decoder, gpsl1, sat_state)
+sat_state = SatelliteState(decoder, gpsl1, tracked_sat)
 ```
 
 Compute the PVT solution:


### PR DESCRIPTION
Follow-up to #60. Every code snippet in the quick-start examples referenced names that don't exist, so copying any of them errored. Each was checked against the loaded packages rather than by eye.

| Location | Was | Now | Why |
| --- | --- | --- | --- |
| `README.md`, `docs/src/index.md` | `GPSL1()` | `GPSL1CA()` | `GNSSSignals.GPSL1` is not defined — the type has been `GPSL1CA` for several majors |
| `docs/src/index.md` | `Tracking.SatState` | `Tracking.TrackedSat` | renamed in Tracking 3; `src/PositionVelocityTime.jl` already had the current name, so only the manual had drifted |
| `README.md` | `SatelliteState(decoder, tracking_result)` | `SatelliteState(decoder, gpsl1, tracked_sat)` | the extension only ever provided the 3-arg form |
| `README.md` | keyword example without `carrier_doppler` | `carrier_doppler` added | it has no default, so it's a required keyword — as written the snippet raised `UndefKeywordError` |
| `docs/src/index.md` | `sat_state = SatelliteState(decoder, gpsl1, sat_state)` | input renamed `tracked_sat` | the result and the argument shared a name; now notes it comes from `get_sat_state` |
| `README.md` | `pkg> PositionVelocityTime.jl` | `pkg> add PositionVelocityTime` | missing `add` |

The README also wrongly claimed the tracking result replaces `system`; `system` is still required, so the prose now says it replaces `code_phase`, `carrier_doppler` and `carrier_phase`.

## Notes

- **No release expected.** Typed `docs:`, which semantic-release does not bump — this is docs-only, no source or compat change.
- **Markdown deliberately left unformatted.** Despite `format_markdown = true` in `.JuliaFormatter.toml`, `README.md` does not currently parse for JuliaFormatter and `docs/src/index.md` is not formatter-clean, so running it would bury these fixes in unrelated reflowing churn. No CI job enforces markdown formatting.
- `docs/make.jl` builds clean locally — only the pre-existing `missing_docs` warnings that `warnonly` already permits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)