### PR TITLE
fix: bound satellite elevation in tropospheric model

### DIFF
--- a/src/troposphere.jl
+++ b/src/troposphere.jl
@@ -12,6 +12,28 @@
 
 const _DEFAULT_RELATIVE_HUMIDITY = 0.7  # GNSS-SDR / RTKLIB default
 
+# Lowest elevation the obliquity mapping is evaluated at. The 1/cos(z) mapping
+# diverges towards the horizon, so a satellite a few tenths of a degree up would be
+# credited a delay of hundreds of metres — enough to drag a least-squares fix off.
+# Below this bound the delay computed *at* the bound is reused, which keeps the
+# correction finite, monotone and continuous across the horizon instead of jumping
+# to zero there.
+#
+# This is a numerical guard, not an estimate: at the bound it yields ≈ 48 m where a
+# curved-atmosphere mapping gives ≈ 37 m, while a genuinely grazing ray is ≈ 90 m.
+# It is defensible only because 1/sin(E) is unusable this low anyway (see #62) and
+# such observations should be masked or de-weighted rather than trusted.
+#
+# The value is taken from Orekit's
+# `ModifiedSaastamoinenModel.DEFAULT_LOW_ELEVATION_THRESHOLD`, but note their bound
+# guards a different failure: Orekit carries Saastamoinen's −B·tan²z curvature term,
+# which goes quadratically negative and inverts the sign of the total delay below
+# E ≈ 1.9°, so 0.05 rad sits just above *that* pathology. Ours has no such term and
+# fails by diverging instead, so the value is borrowed rather than derived — it
+# happens to coincide with the 3° lower validity limit that the mapping-function
+# literature (Niell 1996, VMF3, IERS Conventions ch. 9) settles on.
+const _LOW_ELEVATION_THRESHOLD = 0.05  # rad ≈ 2.87°, caps the mapping at 1/sin ≈ 20
+
 """
     tropospheric_delay(elevation, lla; humidity = 0.7) -> Float64
 
@@ -19,8 +41,10 @@ Slant tropospheric group delay in metres for a satellite at `elevation` (radians
 seen from the user geodetic position `lla` (a `Geodesy.LLA`), using the
 Saastamoinen model driven by a standard atmosphere. The delay is non-dispersive
 (frequency independent). `humidity` is the relative humidity (0…1) used for the
-wet component. Returns `0.0` when the satellite is at or below the horizon or the
-user height is outside the model's valid range (−100 m … 10 km).
+wet component. Elevations below 0.05 rad (≈ 2.87°), including negative ones, are
+treated as 0.05 rad, so the delay saturates near the horizon instead of diverging.
+Returns `0.0` when the user height is outside the model's valid range
+(−100 m … 10 km).
 
 The geometry is taken precomputed so a whole-epoch correction shares the user
 geodetic conversion and the elevation with [`ionospheric_delay`](@ref).
@@ -37,17 +61,26 @@ radians and `height` is the geodetic (ellipsoidal) height in metres. The standar
 atmosphere (pressure, temperature, water-vapour partial pressure) is derived from
 the height with a 15 °C sea-level temperature, and the hydrostatic and wet zenith
 delays are mapped to the slant direction by `1/cos(z)` with `z = π/2 − elevation`.
-Mirrors RTKLIB's `tropmodel`.
+Mirrors RTKLIB's `tropmodel`, except that the elevation is bounded from below by
+`_LOW_ELEVATION_THRESHOLD` (as in Orekit's `ModifiedSaastamoinenModel`): the mapping
+would otherwise grow without bound towards the horizon, so elevations below the
+threshold — including satellites below the horizon — reuse the delay at the
+threshold, roughly 20 × the zenith delay.
+
+The flat-slab `1/cos(z)` mapping over-predicts at low elevation, by ≈ 14 % (≈ 3 m) at
+5° and ≈ 4 % at 10°, since it ignores Earth curvature and ray bending; the bound caps
+the divergence but not that bias. See #62.
 """
 function saastamoinen_delay(latitude, height, elevation, humidity)
-    (height < -100.0 || height > 1.0e4 || elevation <= 0.0) && return 0.0
+    (height < -100.0 || height > 1.0e4) && return 0.0
     hgt = height < 0.0 ? 0.0 : height
     # Standard atmosphere
     pressure = 1013.25 * (1.0 - 2.2557e-5 * hgt)^5.2568          # hPa
     temperature = 15.0 - 6.5e-3 * hgt + 273.16                  # K (15 °C at sea level)
     e = 6.108 * humidity * exp((17.15 * temperature - 4684.0) / (temperature - 38.45))  # hPa
-    # Saastamoinen hydrostatic and wet slant delays (1/cos(z) obliquity mapping)
-    z = π / 2 - elevation
+    # Saastamoinen hydrostatic and wet slant delays (1/cos(z) obliquity mapping),
+    # with the elevation bounded from below so the mapping cannot diverge
+    z = π / 2 - max(elevation, _LOW_ELEVATION_THRESHOLD)
     trph =
         0.0022768 * pressure /
         (1.0 - 0.00266 * cos(2.0 * latitude) - 0.00028 * hgt / 1.0e3) / cos(z)

--- a/test/troposphere.jl
+++ b/test/troposphere.jl
@@ -2,12 +2,13 @@
 # written with sin(elevation) instead of cos(z) and explicit intermediate terms,
 # to cross-check the package's `saastamoinen_delay`.
 function saastamoinen_reference(lat, height, elevation, humidity)
-    (height < -100.0 || height > 1.0e4 || elevation <= 0.0) && return 0.0
+    (height < -100.0 || height > 1.0e4) && return 0.0
     h = max(height, 0.0)
     P = 1013.25 * (1 - 2.2557e-5 * h)^5.2568
     T = 288.16 - 6.5e-3 * h
     e = 6.108 * humidity * exp((17.15 * T - 4684.0) / (T - 38.45))
-    mapping = 1 / sin(elevation)                      # = 1/cos(z), z = π/2 - el
+    el = max(elevation, 0.05)                         # Orekit's low elevation bound
+    mapping = 1 / sin(el)                             # = 1/cos(z), z = π/2 - el
     zhd = 0.0022768 * P / (1 - 0.00266 * cos(2lat) - 0.00028 * h / 1000)
     zwd = 0.002277 * (1255.0 / T + 0.05) * e
     return (zhd + zwd) * mapping
@@ -17,7 +18,7 @@ end
     @testset "matches independent reference" begin
         for lat in deg2rad.((0.0, 48.0, -67.0)),
             h in (0.0, 550.0, 3000.0, 9000.0),
-            el in deg2rad.((5.0, 15.0, 45.0, 90.0)),
+            el in deg2rad.((-10.0, 0.0, 1.0, 5.0, 15.0, 45.0, 90.0)),
             humi in (0.0, 0.5, 0.7, 1.0)
 
             got = PositionVelocityTime.saastamoinen_delay(lat, h, el, humi)
@@ -45,13 +46,34 @@ end
               PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(90.0), 0.0)
     end
 
-    @testset "edge cases return zero" begin
+    @testset "low elevations are bounded" begin
         lat, humi = deg2rad(48.0), 0.7
-        # Satellite at/below the horizon, or user height outside the model's valid
-        # range (−100 m … 10 km), returns exactly zero. The four cases below are, in
-        # order: at horizon, below horizon, too high, too low.
-        @test PositionVelocityTime.saastamoinen_delay(lat, 0.0, 0.0, humi) == 0.0
-        @test PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(-5.0), humi) == 0.0
+        bound = PositionVelocityTime._LOW_ELEVATION_THRESHOLD
+        @test bound == 0.05  # Orekit's DEFAULT_LOW_ELEVATION_THRESHOLD
+        at_bound = PositionVelocityTime.saastamoinen_delay(lat, 0.0, bound, humi)
+        # Everything at or below the bound — grazing, at the horizon, below it — reuses
+        # the delay computed at the bound, so the correction stays finite and continuous
+        # across the horizon instead of diverging or dropping to zero.
+        for el in (bound, 1e-3, 0.0, deg2rad(-5.0), -π / 2)
+            @test PositionVelocityTime.saastamoinen_delay(lat, 0.0, el, humi) == at_bound
+        end
+        # The cap is just the 1/sin(el) mapping evaluated at the bound — ≈ 20 × zenith,
+        # a few tens of metres instead of the hundreds an unbounded mapping gives. It is
+        # a bound, not an accurate low-elevation delay (see #62).
+        zenith = PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(90.0), humi)
+        @test at_bound ≈ zenith / sin(bound) rtol = 1e-12
+        @test at_bound < 50.0
+        # Above the bound the model is untouched and still monotonic in elevation
+        just_above = PositionVelocityTime.saastamoinen_delay(lat, 0.0, 0.06, humi)
+        @test just_above < at_bound
+        @test PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(5.0), humi) <
+              just_above
+    end
+
+    @testset "out-of-range heights return zero" begin
+        lat, humi = deg2rad(48.0), 0.7
+        # User height outside the model's valid range (−100 m … 10 km) returns exactly
+        # zero: too high, then too low.
         @test PositionVelocityTime.saastamoinen_delay(lat, 1.5e4, deg2rad(45.0), humi) == 0.0
         @test PositionVelocityTime.saastamoinen_delay(lat, -200.0, deg2rad(45.0), humi) == 0.0
     end


### PR DESCRIPTION
## Problem

`saastamoinen_delay` maps the zenith delay to the slant direction with
`1/cos(z) = 1/sin(E)`, which diverges as the line of sight approaches the horizon.
A satellite a few tenths of a degree up was credited a slant delay of hundreds or
thousands of metres — far outside the model's validity, and enough to drag a
least-squares fix off. Below the horizon the function returned `0.0` instead, so
there was also a ~48 m → 0 m cliff exactly at the horizon.

At lat 48°, sea level, 70 % RH:

| elevation | before | after |
|---|---|---|
| 90° | 2.43 m | 2.43 m |
| 5° | 27.8 m | 27.8 m |
| 1° | 139 m | 48.6 m |
| 0.1° | 1391 m | 48.6 m |
| 0.01° | 13905 m | 48.6 m |
| ≤ 0° | 0 m | 48.6 m |

## Change

Evaluate the obliquity mapping at `max(elevation, _LOW_ELEVATION_THRESHOLD)` with
`_LOW_ELEVATION_THRESHOLD = 0.05` rad (≈ 2.87°), so elevations at or below the
bound reuse the delay computed *at* the bound. Same construction as Orekit's
`ModifiedSaastamoinenModel.pathDelay`, which computes the zenith angle from
`max(elevation, lowElevationThreshold)` — "for continuity reasons, elevations
lower than a threshold will use the value obtained for the threshold itself".

The `elevation <= 0.0 → 0.0` early return is dropped. Keeping it would leave the
discontinuity at the horizon, which is worse for the solver than a bounded
over-estimate; below-horizon lines of sight now get the bound's delay, as in
Orekit. Height-range handling (−100 m … 10 km → `0.0`) is unchanged.

## What this fix does *not* claim

The cap is a numerical guard, not a delay estimate, and the commit message and
code comments say so:

- At the bound it returns 48.6 m where a curved-atmosphere (Niell) mapping gives
  ≈ 36.6 m, and a genuinely grazing ray is ≈ 90 m. It is neither accurate at
  ~3° nor "the horizon delay" — it is defensible only because `1/sin(E)` is
  unusable that low regardless.
- The threshold value is **borrowed from Orekit, not derived from our formula**.
  Orekit carries Saastamoinen's `−B·tan²z` curvature term, which goes
  quadratically negative and inverts the sign of the total delay below E ≈ 1.9°
  (their formula returns +7.7 m at 2°, −356 m at 1°); their 0.05 rad sits just
  above *that* pathology. Ours has no such term and fails by diverging. The value
  does coincide with the 3° lower validity limit the mapping-function literature
  (Niell 1996, VMF3, IERS Conventions ch. 9) settles on.
- **The low-elevation bias is untouched.** `1/sin(E)` over-predicts by ≈ 14 %
  (≈ 3 m) at 5° and ≈ 4 % at 10° — elevations that do enter the solve, since this
  package applies no elevation mask. That is arguably the more consequential
  defect, and it needs a different mapping function, not a threshold. Filed as
  #62.

## Tests

`test/troposphere.jl`: the independent reference reimplementation gains the same
bound, the cross-check sweep is extended to grazing, zero and negative elevations,
and the old "edge cases return zero" set is split into a bounded-low-elevation set
(clamp identity across the horizon, cap ≈ 20 × zenith, monotonicity preserved just
above the bound) and an out-of-range-height set. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
