### PR TITLE
fix: correct clock drift epoch, velocity singularity and carrier-phase unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ sat_state = SatelliteState(
     system = gpsl1,
     code_phase = code_phase,
     carrier_doppler = carrier_doppler,
-    carrier_phase = carrier_phase # optional
+    carrier_phase = carrier_phase # optional, in radians
 )
 ```
 The declaration of `carrier_phase` is optional due to its small effect on the user position.
+`code_phase` is in chips and `carrier_phase` in radians, matching `Tracking`'s
+`get_code_phase` and `get_carrier_phase`.
 
 Alternatively, a `Tracking.TrackedSat` can be passed to `SatelliteState` instead of
 `code_phase`, `carrier_doppler` and `carrier_phase` — `tracked_sat` below is what

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,9 +34,12 @@ sat_state = SatelliteState(
     system = gpsl1,
     code_phase = code_phase,
     carrier_doppler = carrier_doppler,
-    carrier_phase = carrier_phase,  # optional
+    carrier_phase = carrier_phase,  # optional, in radians
 )
 ```
+
+`code_phase` is in chips and `carrier_phase` in radians, matching `Tracking`'s
+`get_code_phase` and `get_carrier_phase`.
 
 Alternatively, pass a `Tracking.TrackedSat` directly — `tracked_sat` is what
 `Tracking.get_sat_state` returns for a tracked satellite, and the code phase, carrier

--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -107,9 +107,10 @@ Combines the GNSS decoder state with code and carrier phase measurements for a s
 # Fields
 - `decoder::GNSSDecoderState`: GNSS decoder state containing decoded navigation data
 - `system::AbstractGNSSSignal`: GNSS system (e.g., `GPSL1CA()`, `GalileoE1B()`)
-- `code_phase::CP`: Code phase measurement
+- `code_phase::CP`: Code phase measurement in chips
 - `carrier_doppler`: Carrier Doppler frequency in Hz
-- `carrier_phase::CP`: Carrier phase measurement (default: `0.0`)
+- `carrier_phase::CP`: Carrier phase measurement in radians, matching
+  `Tracking.get_carrier_phase` (default: `0.0`)
 
 # Constructors
     SatelliteState(; decoder, system, code_phase, carrier_doppler, carrier_phase=0.0)

--- a/src/sat_position.jl
+++ b/src/sat_position.jl
@@ -109,11 +109,14 @@ function calc_satellite_position_and_velocity(decoder::GNSSDecoder.GNSSDecoderSt
     true_anomaly =
         eccentric_anomaly +
         2 * atan(β * sin(eccentric_anomaly) / (1 - β * cos(eccentric_anomaly)))
+    # Singularity-free form of ν̇. The textbook expression carries a `sin E / sin ν`
+    # ratio, which is `0/0 → NaN` at perigee (`E = ν = 0`) and apogee (`E = ν = π`) —
+    # points every satellite sweeps through twice per orbit. Substituting the identity
+    # `sin ν = √(1−e²)·sin E / (1 − e·cos E)` cancels the ratio into the finite
+    # `(1 − e·cos E)/√(1−e²)`, leaving `ν̇ = Ė·(1 + e·cos ν)/√(1−e²)`: identical away
+    # from those points, finite everywhere.
     true_anomaly_dot =
-        sin(eccentric_anomaly) *
-        eccentric_anomaly_dot *
-        (1.0 + data.e * cos(true_anomaly)) /
-        (sin(true_anomaly) * (1.0 - data.e * cos(eccentric_anomaly)))
+        eccentric_anomaly_dot * (1.0 + data.e * cos(true_anomaly)) / sqrt(1.0 - data.e^2)
     argument_of_latitude = true_anomaly + data.ω
     argrument_of_latitude_correction =
         data.C_us * sin(2 * argument_of_latitude) +

--- a/src/sat_time.jl
+++ b/src/sat_time.jl
@@ -33,7 +33,10 @@ function calc_uncorrected_time(state::SatelliteState)
     chips_per_symbol =
         ustrip(Hz, get_code_frequency(system)) / ustrip(Hz, get_data_frequency(state.decoder))
     t_code_phase = mod(state.code_phase, chips_per_symbol) / get_code_frequency(system) * Hz
-    t_carrier_phase = state.carrier_phase / get_center_frequency(system) * Hz
+    # `carrier_phase` is in radians (that is what `Tracking.get_carrier_phase` reports and
+    # what the Tracking extension passes on), so convert to cycles before dividing by the
+    # centre frequency — unlike the code phase above, which is already in chips.
+    t_carrier_phase = state.carrier_phase / 2π / get_center_frequency(system) * Hz
 
     t_tow + t_bits + t_code_phase + t_carrier_phase
 end
@@ -58,9 +61,17 @@ function correct_clock(decoder::GNSSDecoder.GNSSDecoderState, system, t)
     t - correct_by_group_delay(decoder, system, Δt)
 end
 
+# Rate of the satellite clock correction: the time derivative of the clock polynomial
+# `correct_clock` applies, so it must be evaluated about the same clock reference epoch
+# `t_0c`. Using `t` instead would offset the `a_f2` term by a spurious `2·a_f2·t_0c` —
+# zero whenever `a_f2 = 0` (the usual GPS broadcast) but up to ~4e-9 s/s (≈1.3 m/s of
+# range rate) at the edge of the broadcast range late in the week, and per-satellite,
+# so it would leak into the estimated velocity rather than the common clock drift.
+#
+# The rate of the relativistic periodic term `Δt_rel = F·e·√A·sin(E)` that
+# `correct_clock` includes is not modelled here; it is at most ~1 mm/s.
 function calc_satellite_clock_drift(decoder::GNSSDecoder.GNSSDecoderState, t)
-    decoder.data.a_f1 +
-    decoder.data.a_f2 * t * 2
+    decoder.data.a_f1 + 2 * decoder.data.a_f2 * (t - decoder.data.t_0c)
 end
 
 # Group-delay / inter-signal correction, selected by the *ranging* signal `system`

--- a/test/pvt.jl
+++ b/test/pvt.jl
@@ -12,7 +12,7 @@
         enable_ionospheric_correction = false,
         enable_tropospheric_correction = false,
     )
-    expected_lla = LLA(; lat = 50.778851672464015, lon = 6.065568885758519, alt = 289.4069805158367)
+    expected_lla = LLA(; lat = 50.77885207231635, lon = 6.065568145321566, alt = 289.09688064471146)
     @test pvt.position ≈ ECEFfromLLA(wgs84)(expected_lla) rtol = 1e-8
     @test pvt.time ≈ TAIEpoch(2021, 5, 31, 12, 53, 14.1183385390904732)
     @test pvt.velocity ≈ ECEF(0.0, 0.0, 0.0) atol = 9
@@ -41,7 +41,7 @@ end
         enable_ionospheric_correction = false,
         enable_tropospheric_correction = false,
     )
-    expected_lla = LLA(; lat = 50.77885249310784, lon = 6.0656199911189175, alt = 291.95658091689086)
+    expected_lla = LLA(; lat = 50.778851781017025, lon = 6.065622611231713, alt = 291.96260731963366)
     @test pvt.position ≈ ECEFfromLLA(wgs84)(expected_lla) rtol = 1e-8
     @test pvt.time ≈ TAIEpoch(2021, 5, 31, 12, 53, 14.1491024351271335)
     @test pvt.velocity ≈ ECEF(0.0, 0.0, 0.0) atol = 2.5
@@ -124,7 +124,7 @@ end
     # Independent inter-system-bias solve: 8 GPS + 5 Galileo satellites, with one
     # clock bias per system (3 + 2 unknowns).
     pvt = calc_pvt(states; approximate_year = 2021, enable_ionospheric_correction = false, enable_tropospheric_correction = false)
-    expected_pos = ECEF(4.0186793403460276e6, 427032.98199905816, 4.918251309950126e6)
+    expected_pos = ECEF(4.0186793226897363e6, 427033.09443239716, 4.918251247796992e6)
     @test pvt.position ≈ expected_pos rtol = 1e-8
     @test pvt.velocity ≈ ECEF(-1.4405743822415678, 0.5393693783528187, -2.135825176671574) atol = 1e-3
     @test pvt.time ≈ TAIEpoch(2021, 5, 31, 12, 53, 14.285)

--- a/test/pvt_iono_tropo.jl
+++ b/test/pvt_iono_tropo.jl
@@ -473,9 +473,17 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
         @test PositionVelocityTime.select_ionospheric_correction(states) isa
               PositionVelocityTime.KlobucharParams
 
-        # Corrections are on by default — the fix lands within 0.5 m of the ground truth.
+        # Corrections are on by default — the fix lands within a metre of the ground truth.
+        #
+        # The bound is a metre rather than the decimetres the synthetic geometry might
+        # suggest: these observables carry real captured carrier phases, whose wrapped
+        # fractional cycle shifts each satellite's transmit time by up to half an L1
+        # wavelength. Zeroing them leaves the fix 0.87 m out, so ~1 m is this fixture's own
+        # consistency floor — the tighter 0.5 m held only while the carrier-phase term was
+        # being scaled 2π too large (it read radians as cycles), which happened to pull
+        # this particular constellation towards truth.
         pvt = calc_pvt(states; approximate_year = 2020)
-        @test norm(pvt.position - IONO_TROPO_GROUND_TRUTH) < 0.5
+        @test norm(pvt.position - IONO_TROPO_GROUND_TRUTH) < 1.0
 
         # Disabling the corrections moves the fix several metres off truth, so
         # the corrections demonstrably improve the solution.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Unitful: Hz, m, °, ustrip
 include("aqua.jl")
 include("fixtures.jl")
 include("sat_time.jl")
+include("sat_position.jl")
 include("pvt.jl")
 include("dop.jl")
 include("cnav.jl")

--- a/test/sat_position.jl
+++ b/test/sat_position.jl
@@ -1,0 +1,44 @@
+# Satellite orbit propagation: the velocity half of `calc_satellite_position_and_velocity`.
+#
+# The rates are analytic derivatives of the position expressions, so the reference here is
+# a central difference of the position the same function returns. That also pins the true
+# anomaly rate at perigee and apogee, where the textbook `sin E / sin ν` form of ν̇ is a
+# numerically singular `0/0`.
+@testset "Satellite velocity" begin
+    base = first(galileo_e1b_states(0.0Hz)).decoder
+    t_0e = Float64(base.data.t_0e)
+    # Mean anomaly is `M_0 + n·(t − t_0e)`, so `M_0` places the satellite anywhere on the
+    # orbit at `t = t_0e`; `M = 0`/`M = π` put it exactly at perigee/apogee.
+    at_mean_anomaly(M_0) = let d = GNSSDecoder.GalileoE1BData(base.data; M_0 = M_0)
+        GNSSDecoder.GNSSDecoderState(base; data = d, raw_data = d)
+    end
+    # Central difference of the propagated position, in BigFloat: `t ≈ 1.3e5 s` against a
+    # ~3.6e6 m coordinate leaves too little Float64 headroom for a metre-level difference.
+    function numeric_velocity(decoder, t; h = big(1.0))
+        pos(x) = PositionVelocityTime.calc_satellite_position(decoder, x)
+        (pos(big(t) + h) - pos(big(t) - h)) / (2h)
+    end
+
+    @testset "matches a central difference of the position at M_0 = $M_0" for M_0 in
+                                                                             (0.0, 0.7, Float64(π), 4.2)
+        decoder = at_mean_anomaly(M_0)
+        velocity = PositionVelocityTime.calc_satellite_position_and_velocity(decoder, t_0e).velocity
+        @test all(isfinite, velocity)
+        @test velocity ≈ Float64.(numeric_velocity(decoder, t_0e)) rtol = 1e-6
+    end
+
+    # Perigee (`E = ν = 0`) is an exact `0/0` for the `sin E / sin ν` form; apogee
+    # (`E = ν = π`) is saved from a hard NaN only by `sin(π) != 0` in floating point, but
+    # is still ill-conditioned there. Sweep across both to make sure no sample degrades.
+    @testset "stays finite sweeping through perigee and apogee" begin
+        for M_0 in (0.0, Float64(π))
+            decoder = at_mean_anomaly(M_0)
+            velocities = [
+                PositionVelocityTime.calc_satellite_position_and_velocity(decoder, t).velocity
+                for t in range(t_0e - 1, t_0e + 1; length = 101)
+            ]
+            @test all(v -> all(isfinite, v), velocities)
+            @test all(v -> norm(v) > 1000, velocities)   # a MEO satellite moves ~3.7 km/s
+        end
+    end
+end

--- a/test/sat_time.jl
+++ b/test/sat_time.jl
@@ -5,3 +5,73 @@
 
     @test PositionVelocityTime.correct_week_crossovers(-350000) == 604800 - 350000
 end
+
+# `calc_satellite_clock_drift` must be the time derivative of the clock correction that
+# `correct_clock` applies, so it has to be evaluated about the clock reference epoch
+# `t_0c` — not about `t`, which would offset the `a_f2` term by `2·a_f2·t_0c`.
+@testset "Satellite clock drift is the derivative of the clock correction" begin
+    base = first(galileo_e1b_states(0.0Hz)).decoder
+    with(; kwargs...) = let d = GNSSDecoder.GalileoE1BData(base.data; kwargs...)
+        GNSSDecoder.GNSSDecoderState(base; data = d, raw_data = d)
+    end
+    # The applied correction, differentiated in BigFloat: the Float64 round trip through
+    # `correct_clock` (t ≈ 6e5 s, correction ≈ 2e-4 s) loses the ~1e-13 s difference.
+    function numeric_drift(decoder, t)
+        applied(x) = x - PositionVelocityTime.correct_clock(decoder, GalileoE1B(), x)
+        h = big(1.0)
+        (applied(big(t) + h) - applied(big(t) - h)) / (2h)
+    end
+
+    @testset "a_f2 = 0 (the usual broadcast): drift is a_f1" begin
+        decoder = with(; a_f1 = 1e-11, a_f2 = 0.0, t_0c = 132000.0)
+        t = 132100.0
+        @test PositionVelocityTime.calc_satellite_clock_drift(decoder, t) == 1e-11
+        @test PositionVelocityTime.calc_satellite_clock_drift(decoder, t) ≈
+              Float64(numeric_drift(decoder, t)) atol = 1e-13
+    end
+
+    @testset "non-zero a_f2 late in the week: no spurious 2·a_f2·t_0c offset" begin
+        # |a_f2| at the edge of the broadcast range (8 bit, LSB 2^-55 s/s²) with a clock
+        # reference epoch near the end of the week — the worst case for the offset.
+        a_f2, t_0c = 3.5e-15, 604000.0
+        decoder = with(; a_f1 = 1e-11, a_f2 = a_f2, t_0c = t_0c)
+        t = t_0c + 100.0
+
+        drift = PositionVelocityTime.calc_satellite_clock_drift(decoder, t)
+        @test drift ≈ 1e-11 + 2 * a_f2 * 100.0
+        # Within the neglected relativistic-rate term, well below the 4.2e-9 s/s
+        # (≈1.3 m/s of range rate) the `t`-based polynomial would have been off by.
+        @test drift ≈ Float64(numeric_drift(decoder, t)) atol = 1e-13
+        @test !isapprox(drift, 1e-11 + 2 * a_f2 * t, atol = 1e-12)
+    end
+end
+
+# The carrier-phase term refines the transmit time by a fraction of a carrier cycle.
+# `SatelliteState.carrier_phase` is in radians (`Tracking.get_carrier_phase`), so it must
+# be converted to cycles before being divided by the centre frequency.
+@testset "Carrier-phase transmit-time term treats carrier_phase as radians" begin
+    system = GPSL1CA()
+    decoder = GNSSDecoder.GNSSDecoderState(
+        GNSSDecoderState(system, 1);
+        num_bits_after_valid_syncro_sequence = 0,
+        data = GNSSDecoder.GPSL1CAData(; TOW = 0),
+        raw_data = GNSSDecoder.GPSL1CAData(; TOW = 0),
+    )
+    time_of(carrier_phase) = PositionVelocityTime.calc_uncorrected_time(
+        SatelliteState(; decoder, system, code_phase = 0.0, carrier_doppler = 0.0Hz,
+            carrier_phase),
+    )
+
+    for cycles in (0.25, 0.5, -0.5)
+        @test time_of(cycles * 2π) ≈ cycles / ustrip(Hz, get_center_frequency(system))
+    end
+    # The wrapped carrier phase spans one cycle, so the term is bounded by half a carrier
+    # wavelength of range — ~9.5 cm on L1, not the ~60 cm a radians-as-cycles reading gives.
+    half_wavelength =
+        0.5 * PositionVelocityTime.SPEEDOFLIGHT / ustrip(Hz, get_center_frequency(system))
+    @test half_wavelength ≈ 0.0952 atol = 1e-4
+    @test maximum(
+        abs(time_of(φ) * PositionVelocityTime.SPEEDOFLIGHT) for
+        φ in range(-Float64(π), Float64(π); length = 21)
+    ) ≈ half_wavelength
+end


### PR DESCRIPTION
Fixes three independent defects in the satellite clock, orbit and transmit-time models. Each was confirmed by running the code before being fixed, and each regression test was mutation-checked — reverting the source makes it fail.

Closes #41
Closes #42
Closes #59

## #41 — clock drift evaluated at `t` instead of `(t − t_0c)`

`calc_satellite_clock_drift` evaluated the drift polynomial at `t`, so it was not the derivative of the polynomial `correct_clock` applies. The `a_f2` term carried a spurious `2·a_f2·t_0c`.

Differentiating the correction `correct_clock` actually applies (numerically, in `BigFloat` — the Float64 round trip loses the ~1e-13 s difference to cancellation at t ≈ 6e5 s):

| ephemeris | current | numeric truth | error |
|---|---|---|---|
| `a_f2 = 0` (what operators usually broadcast) | 1.0e-11 | 1.0022e-11 | ~0 |
| `a_f2 = 3.5e-15`, `t_0c = 604000` | 4.2387e-9 | 1.073e-11 | **4.23e-9 s/s ≈ 1.27 m/s** |

Because `a_f2` and `t_0c` are per-satellite, the error is not common-mode: it leaks into the estimated user velocity rather than the clock drift. After the fix the residual is 2.9e-14 s/s — the neglected rate of the relativistic periodic term, left out here since it is a separate modelling question (µm/s on these ephemerides, ~1 mm/s worst case).

## #42 — true-anomaly rate divided by `sin(ν)`

The rate was computed by dividing by `sin(true_anomaly)`, which is `0/0` at perigee and apogee — points every satellite sweeps through twice per orbit. Replaced with the equivalent singularity-free closed form `ν̇ = Ė·(1 + e·cos ν)/√(1 − e²)`.

This is worse than the issue reported. Perigee gives a hard `[NaN, NaN, NaN]` that propagates through the entire velocity vector into the receiver velocity/clock-drift solve. Apogee escapes the NaN only because `sin(π)` is `1.22e-16` rather than `0` in floating point — but the ratio is then meaningless: measured against a central difference of the propagated position, the old expression was off by **~0.8 m/s at apogee**. So the defect bites even without an exact zero landing on `E`.

## #59 — `carrier_phase` treated as cycles, but supplied in radians

`calc_uncorrected_time` divided `carrier_phase` by the centre frequency, which yields a time only for a phase in cycles. `Tracking.get_carrier_phase` — the source the Tracking extension feeds it from — reports radians, so the carrier-phase term of the transmit time was 2π too large (reproduction ratio: exactly 2π).

`Tracking`'s convention verified at the source: the `TrackedSat` constructor stores `float(carrier_phase) / 2π` and the accessor returns `s.carrier_phase * 2π`. Corroborating, every `carrier_phase` in this repo's captured fixtures lies in [−π, π] — impossible as a wrapped cycle count.

The wrapped phase should refine the transmit time by at most half an L1 wavelength (±9.5 cm); it contributed up to ±60 cm. It does not cancel across satellites and is not noise-like, so it entered as a smoothly varying per-satellite pseudorange error.

**Direction chosen.** The issue offered two options. This scales at the point of use rather than having the extension pass cycles, so the conversion lives in one place instead of in every producer of a `SatelliteState`, and the public field keeps the unit it de facto already carries — no silent breakage for external callers. The unit is now stated on the field and in the README/docs quick start, since the missing unit is what made the mismatch easy to miss. Happy to flip the field to cycles instead if you prefer; that additionally needs every fixture value divided by 2π.

## Test changes

New testsets in `test/sat_time.jl` and a new `test/sat_position.jl`; satellite velocity is validated against a central difference of the position the same function returns, which pins the rates rather than just asserting finiteness.

Two fixture updates follow from #59:

- The recorded PVT regression positions move 0.13–0.32 m (Galileo, GPS, combined).
- The synthetic iono/tropo ground-truth bound goes 0.5 m → 1.0 m. With the carrier-phase term zeroed that fixture is already 0.87 m off truth, so ~1 m is its own consistency floor; the tighter bound held only because the 2π-inflated term happened to pull that particular constellation toward truth. The "corrections beat uncorrected" assertions (9.0 m vs 0.76 m) are unchanged.

## Noticed, not addressed

Pre-existing and unrelated to these fixes: the `pvt.time` pins at `test/pvt.jl:17` and `:46` are stale by ~0.15 s and assert nothing useful — `≈` on `TAIEpoch` compares seconds-since-J2000, giving a tolerance of ~10 s. Left alone as out of scope; worth tightening separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
