### PR TITLE
feat: support Tracking.jl v6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ LinearAlgebra = "1"
 LsqFit = "0.12, 0.13, 0.14, 0.15, 0.16"
 StaticArrays = "1"
 Test = "1"
-Tracking = "3, 4, 5"
+Tracking = "3, 4, 5, 6"
 Unitful = "1"
 julia = "1.10"
 


### PR DESCRIPTION
Widens the `Tracking` compat to `"3, 4, 5, 6"`, now that [Tracking v6.0.0 is registered](https://github.com/JuliaRegistries/General/pull/163510). `Tracking` is a weak dependency here (backing the `PositionVelocityTimeTrackingExt` extension) plus a test dependency, so the single widened bound covers both.

## Why v6's breaking changes don't reach this package

**`estimate_cn0` now defaults to NWPR** instead of the moment ratio, so its numbers shift and it can read `-Inf dB-Hz` on noise. Nothing here calls it. The extension builds a `SatelliteState` from a `Tracking.TrackedSat` using only `get_code_phase`, `get_carrier_doppler` and `get_carrier_phase`, and the integration test pins its solve to satellites selected by decoded ephemeris health (`is_sat_healthy`), never by C/N₀ — so the reference fix is unaffected.

**`TrackedSignal` gained a fifth type parameter** (`TrackedSignal{Sig, B, C, PCF, CN0}`) holding the estimator type. Only code that spells the type out with exactly four parameters as a concrete type must adapt. This package never names the type — not in a method signature, not as a stored slot type.

## Verification

Run against Tracking v6.0.0 (dev'd from `2077a39`, the registered tag):

- Full suite passes, including `test/tracking_ext.jl` (**7/7**) and a clean `PositionVelocityTimeTrackingExt` precompile
- Opt-in real-data integration test: **8/8** pass — `test/pvt_integration.jl`, the Flexiband L125 Nuremberg-roof capture, whose reference position still resolves within tolerance

🤖 Generated with [Claude Code](https://claude.com/claude-code)