### PR TITLE
feat!: report post-fit range-rate residuals per satellite

### DIFF
--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -162,11 +162,17 @@ satellite used in the fix).
 - `residual::typeof(1.0m)`: Post-fit least-squares pseudorange residual (metres) — the
   modeled minus the (atmosphere-corrected) measured pseudorange. A per-satellite
   fit-quality / outlier indicator.
+- `rate_residual::typeof(1.0m/s)`: Post-fit least-squares range-rate residual (metres per
+  second) — the modeled minus the measured range rate of the carrier-Doppler velocity and
+  clock-drift solve. The rate-domain counterpart of `residual`: it flags a satellite whose
+  Doppler disagrees with the velocity fix (cycle slips, dynamics) independently of its
+  pseudorange.
 """
 struct SatInfo
     position::ECEF
     time::Float64
     residual::typeof(1.0m)
+    rate_residual::typeof(1.0m/s)
 end
 
 """
@@ -211,8 +217,9 @@ Complete Position, Velocity, and Time solution from GNSS measurements.
 - `relative_clock_drift::Float64`: Relative receiver clock drift (dimensionless)
 - `dop::Union{DOP, Nothing}`: Dilution of precision values
 - `sats::Dictionary{Tuple{Symbol, Int}, SatInfo}`: Maps `(signal, PRN)` to satellite
-  info — position, transmit time, and post-fit residual (see [`SatInfo`](@ref)). The
-  signal tag (e.g. `:GPSL1CA`, `:GalileoE1B`; see `get_signal_id`) keeps the
+  info — position, transmit time, and the post-fit pseudorange and range-rate
+  residuals (see [`SatInfo`](@ref)). The signal tag (e.g. `:GPSL1CA`,
+  `:GalileoE1B`; see `get_signal_id`) keeps the
   same PRN apart both across constellations (GPS PRN 5 vs Galileo E05) and across
   signals of one constellation (a satellite tracked on GPS L1 C/A and L5 yields two
   entries sharing a PRN). Receiver-clock grouping is by time system, not signal —
@@ -261,7 +268,8 @@ end
 """
     get_sat_info(pvt_solution::PVTSolution, signal::Symbol, prn::Integer) -> Union{SatInfo,Nothing}
 
-Return the [`SatInfo`](@ref) (position, transmit time and post-fit residual) of the
+Return the [`SatInfo`](@ref) (position, transmit time and the post-fit
+pseudorange/range-rate residuals) of the
 satellite with the given `prn` on GNSS `signal` (e.g. `:GPSL1CA`, `:GalileoE1B`; see
 `get_signal_id`), or `nothing` if that satellite was not used in the fix. The
 signal tag is required because the same PRN can belong to different constellations or
@@ -759,7 +767,7 @@ function calc_pvt(
     dop = calc_DOP(H, position, primary_clock_index)
     dop.GDOP < 0 && return prev_pvt
 
-    user_velocity_and_clock_drift = calc_user_velocity_and_clock_drift(
+    user_velocity_and_clock_drift, rate_residuals = calc_user_velocity_and_clock_drift(
         sat_positions_and_velocities, healthy_states, times, H)
     velocity = ECEF(
         user_velocity_and_clock_drift[1],
@@ -782,7 +790,7 @@ function calc_pvt(
         corrected_reference_time - floor(Int, corrected_reference_time),
     )
 
-    sat_infos = SatInfo.(sat_positions, times, residuals .* m)
+    sat_infos = SatInfo.(sat_positions, times, residuals .* m, rate_residuals .* (m/s))
 
     # Inter-system biases relative to the reference (primary) system's clock, in
     # meters. The reference is omitted (its bias is `time_correction`); for a

--- a/src/user_position.jl
+++ b/src/user_position.jl
@@ -256,8 +256,9 @@ Computes user velocity
 
 $SIGNATURES
 
-Calculates the user velocity and a single receiver clock drift, returned as
-`[vx, vy, vz, ċ]`. Unlike the position solve — which estimates one clock *bias*
+Calculates the user velocity and a single receiver clock drift, returned together with
+the per-satellite post-fit range-rate residuals as `([vx, vy, vz, ċ], rate_residuals)`.
+Unlike the position solve — which estimates one clock *bias*
 per GNSS time system (the inter-system bias / GGTO is metre-level and must be
 resolved) — a single clock *drift* is shared by all satellites regardless of
 GNSS: the receiver has one oscillator, and the only per-system difference is the
@@ -265,6 +266,11 @@ drift of the inter-system time offset (e.g. the GGTO rate `A_1G`), which is
 ~1e-6 m/s — far below the Doppler velocity resolution. Using one common drift lets
 every satellite constrain the four unknowns instead of spending a column per
 system.
+
+The residuals are `modeled − measured` range rate (m/s), the same orientation as the
+pseudorange residuals of [`user_position`](@ref) and in the same satellite order as
+`states`. They are the range-rate analogue of the post-fit pseudorange residual: a
+per-satellite Doppler-consistency / outlier indicator.
 
 Requires a geometry whose position design `H` has full column rank — the caller
 establishes that with [`calc_DOP`](@ref) before calling this; see the comment at the solve.
@@ -281,6 +287,11 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states
     # evaluated per satellite from its own carrier frequency.
     HtH = zero(SMatrix{4,4,Float64})
     Hty = zero(SVector{4,Float64})
+    # The normal-equations form does not keep the design rows, so the measurements are
+    # kept here instead and turned into post-fit residuals in place after the solve —
+    # cheaper than a second pass that recomputes each `yⱼ` (Doppler, wavelength and
+    # satellite clock drift) from the decoder.
+    rate_residuals = Vector{Float64}(undef, num_sats)
     for j in 1:num_sats
         state = states[j]
         sat_pv = sat_positions_and_velocities[j]
@@ -292,6 +303,7 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states
         e = SVector{3}(view(H, j, 1:3))
         a = SVector(e[1], e[2], e[3], 1.0)
         yⱼ = -(doppler * λ - clock_drift * SPEEDOFLIGHT - dot(e, get_sat_velocity(sat_pv)))
+        rate_residuals[j] = yⱼ
         HtH += a * a'
         Hty += a * yⱼ
     end
@@ -305,7 +317,18 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states
     # This is why `calc_pvt` must keep the DOP check *ahead* of this call: with the order
     # reversed, a rank-deficient geometry reaches the solve below and throws
     # `SingularException` — the failure this arrangement exists to prevent.
-    cholesky(Symmetric(HtH)) \ Hty
+    velocity_and_drift = cholesky(Symmetric(HtH)) \ Hty
+
+    # Post-fit residual, modeled minus measured: the design row `[e 1]` (rebuilt from
+    # H's line-of-sight columns, as above) applied to the solved state, minus the
+    # measurement stored in the accumulation loop.
+    velocity = SVector{3}(
+        velocity_and_drift[1], velocity_and_drift[2], velocity_and_drift[3])
+    for j in 1:num_sats
+        e = SVector{3}(view(H, j, 1:3))
+        rate_residuals[j] = dot(e, velocity) + velocity_and_drift[4] - rate_residuals[j]
+    end
+    return velocity_and_drift, rate_residuals
 end
 
 get_sat_position(x) = x.position

--- a/test/pvt.jl
+++ b/test/pvt.jl
@@ -168,6 +168,13 @@ end
     @test all(isfinite, resids)
     @test maximum(abs, resids) < 10m
 
+    # The rate-domain counterpart from the Doppler solve (modeled − measured range
+    # rate, m/s): finite, and metre-per-second-level for a stationary receiver.
+    rate_resids = [info.rate_residual for info in values(pvt.sats)]
+    @test length(rate_resids) == length(pvt.sats)
+    @test all(isfinite, rate_resids)
+    @test maximum(abs, rate_resids) < 10.0m/s
+
     warm_pvt = calc_pvt(states, pvt; approximate_year = 2021, enable_ionospheric_correction = false, enable_tropospheric_correction = false)
     @test get_LLA(warm_pvt) ≈ get_LLA(pvt)
     @test warm_pvt.time ≈ pvt.time
@@ -382,12 +389,12 @@ end
         # The case no satellite count can see: four *distinct* satellites — plenty for the
         # 3 + 1 unknowns — whose lines of sight lie on a common cone (equal projection onto
         # z), which puts the clock column in their span.
-        c = 0.5
-        s = sqrt(1 - c^2)
-        cone = [s 0.0 c; 0.0 s c; -s 0.0 c; 0.0 -s c]
+        cosθ = 0.5
+        sinθ = sqrt(1 - cosθ^2)
+        cone = [sinθ 0.0 cosθ; 0.0 sinθ cosθ; -sinθ 0.0 cosθ; 0.0 -sinθ cosθ]
         @test !full_rank([cone ones(4)])
         # Tilting one satellite off the cone restores full rank.
-        tilted = [cone[1:3, :]; normalize([0.0, -s, 2c])']
+        tilted = [cone[1:3, :]; normalize([0.0, -sinθ, 2cosθ])']
         @test full_rank([tilted ones(4)])
     end
 
@@ -411,11 +418,21 @@ end
         velocity_and_drift(dirs) = PositionVelocityTime.calc_user_velocity_and_clock_drift(
             sat_pvs, states, times, design(dirs))
 
-        # Four well-spread directions ⇒ solvable: a finite [vx, vy, vz, ċ].
-        solution = velocity_and_drift(
+        # Four well-spread directions ⇒ solvable: a finite [vx, vy, vz, ċ], plus one
+        # finite post-fit range-rate residual per satellite.
+        solution, rate_residuals = velocity_and_drift(
             [[1.0, 0.2, 0.9], [-0.5, 1.0, 0.7], [0.3, -1.0, 0.5], [0.0, 0.1, 1.0]])
         @test length(solution) == 4
         @test all(isfinite, solution)
+        @test length(rate_residuals) == length(states)
+        @test all(isfinite, rate_residuals)
+        # A post-fit least-squares residual is orthogonal to every column of its design
+        # — the line-of-sight columns and the common clock-drift column of ones. That is
+        # what makes it a residual rather than an arbitrary modeled-minus-measured
+        # difference, so it is pinned directly instead of only by magnitude.
+        let A = design([[1.0, 0.2, 0.9], [-0.5, 1.0, 0.7], [0.3, -1.0, 0.5], [0.0, 0.1, 1.0]])
+            @test norm(A' * rate_residuals) < 1e-6
+        end
 
         # The degenerate cases are stated on the design matrix, since the solve itself no
         # longer tests rank. Two distinct directions (a satellite tracked on a second band
@@ -427,8 +444,9 @@ end
         # Three independent directions on a common cone (equal projection onto z) put the
         # drift column in their span, leaving the fourth pivot exactly zero — the shape
         # that produced SingularException(4) from the 4×4 solve.
-        c = 0.5
-        s = sqrt(1 - c^2)
-        @test !solvable([[s, 0.0, c], [0.0, s, c], [-s, 0.0, c], [0.0, -s, c]])
+        cosθ = 0.5
+        sinθ = sqrt(1 - cosθ^2)
+        @test !solvable([
+            [sinθ, 0.0, cosθ], [0.0, sinθ, cosθ], [-sinθ, 0.0, cosθ], [0.0, -sinθ, cosθ]])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 
 using Test, PositionVelocityTime, GNSSDecoder, AstroTime, GNSSSignals, Geodesy, Dates, LinearAlgebra
-using Unitful: Hz, m, °, ustrip
+using Unitful: Hz, m, s, °, ustrip
 
 include("aqua.jl")
 include("fixtures.jl")


### PR DESCRIPTION
## What

`SatInfo` gains `rate_residual`, the Doppler-solve counterpart of the existing pseudorange `residual`: modeled minus measured range rate in m/s, per satellite, in the same orientation as `residual`.

It flags a satellite whose Doppler disagrees with the velocity fix independently of its pseudorange — see the worked example below, where it catches an outlier the pseudorange residual does not see at all.

## How

The velocity solve accumulates normal equations (`HᵀH`, `Hᵀy`) and never materialises its design matrix, so the residuals are not free the way the least-squares pseudorange ones are. Rather than a second pass recomputing each measurement from the decoder (Doppler, wavelength, satellite clock drift), the measurements are stashed in one `Vector{Float64}` during the accumulation loop and overwritten in place with the residual afterwards, reusing `H`'s line-of-sight columns for the design row.

`calc_user_velocity_and_clock_drift` now returns `([vx, vy, vz, ċ], rate_residuals)`, mirroring `user_position`'s `(ξ, residuals)`.

## Cost

Min of 3 runs each, `benchmark/fixtures.jl` inputs, Julia 1.12:

| `calc_pvt` | time (base → new) | allocs | bytes |
|---|---|---|---|
| Galileo 5 cold | 20.49 → 20.52 µs | 591 → 593 | 26560 → 26768 |
| Galileo 5 warm | 10.06 → 9.98 µs | 433 → 435 | 17040 → 17184 |
| GPS 9 cold | 31.09 → 30.71 µs | 791 → 793 | 32944 → 33232 |
| GPS 9 warm | 17.86 → 17.89 µs | 633 → 635 | 22912 → 23136 |

End-to-end time change is below run-to-run noise — several baseline runs came out slower than the new ones. Isolated, the velocity solve goes 0.22 → 0.25 µs at 9 sats and stops being allocation-free.

**+2 allocations, +144…288 B per epoch**, fully accounted for: one `Vector{Float64}(undef, num_sats)` (2 GC allocs on Julia ≥1.11 — Memory plus Array wrapper), and `SatInfo` growing 40 → 48 bytes, paid twice (the `sat_infos` vector and the `Dictionary`'s value array).

## What it found immediately

On the GPS+Galileo test fixture the combined rate residuals reach 5.15 m/s while single-system ones sit at 0.5–1.1 m/s. That is **not** an inter-system drift — it is one satellite, **Galileo E04 at 9.1° elevation**, whose measurement sits ~7.5 m/s off the pack (≈39 Hz at the 0.190 m E1 wavelength):

```
y (m/s), which for a stationary receiver should be ~one constant drift
GPS:     -310.81 -312.16 -311.68 -310.95 -312.37 -311.57 -312.85 -311.53 -312.81
Galileo: -312.22 -319.61 -312.23 -312.44 -314.95
                  ^^^^^^ E04

leave-one-out ‖r‖ of the combined solve (baseline 7.391)
  drop E04 -> 3.292      next best is G15 (7.1° elev) at 5.954
```

Ruled out along the way:

- **Inter-system drift.** A per-system drift column does drop ‖r‖ from 7.39 to 6.00, but with E04 removed the fitted Δ collapses from −2.41 to −0.93 m/s and the common-drift model is nearly as good as the per-system one (3.29 vs 2.94). The broadcast GGTO rate `A_1G` is ~1e-6 m/s anyway, six orders of magnitude below this.
- **Our ephemeris.** Every satellite's analytic velocity agrees with a central difference of the analytic position to 2–3e-6 m/s, E04 included.

Why single-system hid it: Galileo-only is 5 satellites against 4 unknowns — 1 degree of freedom, so the outlier is absorbed into the state rather than the residuals. The Galileo-only fix reports `v = [-5.80, 0.97, -5.82]` for a receiver that was stationary in Aachen, an ~8 m/s error, while its residuals still look innocuous. E04's *pseudorange* residual is an unremarkable −2.29 m, well inside the pack — nothing in the existing diagnostics flagged it.

The two largest rate residuals overall belong to the two lowest-elevation satellites in the set (E04 at 9.1°, G15 at 7.1°). An elevation-weighted velocity solve is the obvious follow-up; the position solve has the same `wt` idea sitting commented out at `src/user_position.jl:249`.

## Tests

Full suite passes. Beyond magnitude and finiteness bounds, the tests pin the defining property directly — a post-fit least-squares residual is orthogonal to every column of its design (`‖Aᵀr‖ < 1e-6`, verifies at ~1e-12). That is what distinguishes a residual from an arbitrary modeled-minus-measured difference.

## Breaking

`SatInfo` gains a field, so the exported struct's positional-constructor arity/order and field layout change — same shape of break as 4.0.0's `course_over_ground` addition. Keyword construction and field access are unaffected; positional construction and reflection-based code must be updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
