### PR TITLE
fix: run the position solve to its optimum

### DIFF
--- a/src/user_position.jl
+++ b/src/user_position.jl
@@ -228,8 +228,27 @@ function user_position(sat_positions_mat, ρ, bias_columns::BiasColumns, prev_ξ
     model! = (out, x, par) -> calc_ρ_hat!(out, x, par, bias_columns)
     jacobian! = (J, x, par) -> calc_H!(J, x, par, bias_columns)
 
-    # Geodesic acceleration helps when starting far from the optimum (cold start
-    # from origin, ~6e6 m away) by trading per-iteration work for fewer iterations.
+    # Two departures from LsqFit's Levenberg-Marquardt defaults, both about the scale of
+    # this particular problem:
+    #
+    #  - `x_tol` is a *relative* step tolerance — the iteration stops once a step falls
+    #    below `x_tol·(x_tol + ‖ξ‖)` — and `‖ξ‖` here is dominated not by the position but
+    #    by the clock bias, which carries the ~2e7 m of common range the pseudoranges are
+    #    referred to. The 1e-8 default therefore calls it converged at a step of ~0.2 m,
+    #    so a solve that starts a metre from the optimum — an ordinary warm start from the
+    #    previous epoch — stops most of a metre short of it. 1e-13 puts the threshold at a
+    #    ~2 µm step, still ~1e3 × the rounding resolution of `ξ`.
+    #  - `lambda` is the initial (inverse) trust-region radius, and the default 10 damps
+    #    the first steps to a fraction of the Gauss-Newton step — which is what makes the
+    #    tolerance above bite so early. The pseudorange model is only mildly nonlinear, so
+    #    the full step is a good step here: 1e-8 leaves the iteration effectively
+    #    Gauss-Newton — measured at 2 to 5 iterations to nanometre level from 1 m, 100 km
+    #    or a cold start, against 8 to 16 with the default or with damping switched off
+    #    entirely — while keeping LM's machinery available, since a step that fails to
+    #    improve still grows `lambda` from there.
+    #
+    # Geodesic acceleration additionally helps when starting far from the optimum (cold
+    # start from origin, ~6e6 m away) by trading per-iteration work for fewer iterations.
     # When prev_ξ is already near-converged, the extra Avv! evals are pure overhead.
     # Detect cold by checking the default zeros sentinel (origin position).
     ξ_fit_ols = if iszero(prev_ξ)
@@ -237,13 +256,16 @@ function user_position(sat_positions_mat, ρ, bias_columns::BiasColumns, prev_ξ
             model!, jacobian!, sat_positions_mat, ρ, collect(prev_ξ);
             inplace = true,
             avv! = (dir_deriv, par, v) -> calc_Avv!(dir_deriv, sat_positions_mat, par, v),
-            lambda = 0.0,
+            lambda = 1e-8,
             min_step_quality = 0.0,
+            x_tol = 1e-13,
         )
     else
         curve_fit(
             model!, jacobian!, sat_positions_mat, ρ, collect(prev_ξ);
             inplace = true,
+            lambda = 1e-8,
+            x_tol = 1e-13,
         )
     end
     #    wt = 1 ./ (ξ_fit_ols.resid .^ 2)

--- a/test/pvt.jl
+++ b/test/pvt.jl
@@ -450,3 +450,35 @@ end
             [sinθ, 0.0, cosθ], [0.0, sinθ, cosθ], [-sinθ, 0.0, cosθ], [0.0, -sinθ, cosθ]])
     end
 end
+
+# Regression: the position solve must run to its optimum, not stop at the first step
+# LsqFit's *relative* `x_tol` calls small. `‖ξ‖` is dominated by the clock bias — the
+# ~2e7 m of common range the pseudoranges are referred to — which puts the default
+# tolerance at a ~0.2 m step, and with the default Levenberg-Marquardt damping a first
+# step is only a fraction of the distance to the optimum. A warm start a metre out
+# therefore took one ~10 cm step and reported convergence, returning a fix most of a
+# metre away from the one the very same measurements give from cold. See the solver
+# settings in `user_position`.
+@testset "a warm start converges to the same fix as a cold start" begin
+    kwargs = (; approximate_year = 2021, enable_ionospheric_correction = false,
+        enable_tropospheric_correction = false)
+    states = gps_l1_states(0.0Hz)
+    cold = calc_pvt(states; kwargs...)
+
+    # Previous solutions displaced by 1 m, 30 m and 100 km. With no position-dependent
+    # correction active the measurements define one optimum, so every start must reach
+    # it — to well under a millimetre, not to within the starting error.
+    for offset in ([1.0, -1.0, 1.0], [30.0, 0.0, -20.0], [1e5, 1e5, -1e5])
+        stale = PVTSolution(;
+            position = ECEF((Vector(cold.position) .+ offset)...),
+            time_correction = cold.time_correction,
+            reference_system = cold.reference_system,
+        )
+        warm = calc_pvt(states, stale; kwargs...)
+        @test norm(warm.position - cold.position) < 1e-4
+        @test warm.time ≈ cold.time
+        # The residuals are those of the converged fit, not of the stale position.
+        @test maximum(abs, [info.residual for info in values(warm.sats)]) ≈
+              maximum(abs, [info.residual for info in values(cold.sats)]) rtol = 1e-6
+    end
+end


### PR DESCRIPTION
## The bug

`user_position` lets `LsqFit.curve_fit` stop far short of the least-squares optimum on a warm start. Two defaults conspire:

- **`x_tol` is a *relative* step tolerance** — the iteration stops once a step falls below `x_tol·(x_tol + ‖ξ‖)` — and `‖ξ‖` here is dominated not by the position but by the clock bias, which carries the ~2e7 m of common range the pseudoranges are referred to. The 1e-8 default therefore declares convergence at a step of **~0.2 m**.
- **`lambda = 10`** damps the first Levenberg-Marquardt steps to a fraction of the Gauss-Newton step, so the step size crosses that threshold long before the iterate reaches the optimum.

Seeded a metre from the optimum — the ordinary epoch-to-epoch warm start — the solve took one ~10 cm step and reported success:

| warm start displaced by | position returned, distance from the cold-start fix | max post-fit residual |
|---|---|---|
| 1 m | **1.56 m** | 2.58 m (cold: 1.30 m) |
| 30 m | ~0 m | ✓ |
| 100 km | ~1e-5 m | ✓ |

Paradoxically only the *small* displacement is affected: from further away the first steps are large enough to keep the iteration running until it converges. The reported residuals are those of the unconverged position, so they mis-report fit quality too. The cold path was never affected — it already ran undamped.

## The fix

Tighten `x_tol` to 1e-13 (a ~2 µm step, still ~1e3 × the rounding resolution of `ξ`) and start `lambda` at 1e-8 rather than 10.

The tiny non-zero lambda leaves the iteration effectively Gauss-Newton, which suits a problem this mildly nonlinear, while keeping LM's machinery available — a step that fails to improve still grows lambda from there, unlike `lambda = 0`, where a rejected step can never shrink the trust region and the solver just burns iterations. Measured iterations to reach the optimum (nanometre level):

| settings | from 1 m | from 100 km | cold start | converged? |
|---|---|---|---|---|
| `lambda=10`, `x_tol=1e-8` (before) | 1 | 8 | — | ✗ stops 1.7 m out |
| `lambda=0`, `x_tol=1e-13` | 2 | 4 | 16 | ✓ |
| **`lambda=1e-8`, `x_tol=1e-13`** | **2** | **4** | **5** | ✓ |

## Cost

`calc_pvt` moves by −35 % to +31 % depending on the epoch, all within 10–33 µs: warm starts and 4-satellite fixes get *cheaper* (GPS 4-sat warm 19.0 → 12.3 µs), while the Galileo 5-satellite cold start pays ~6 µs (20.3 → 26.7 µs) for the iterations it previously skipped.

## Test

`test/pvt.jl` gains "a warm start converges to the same fix as a cold start": with no position-dependent correction active the measurements define one optimum, so warm starts displaced by 1 m, 30 m and 100 km must all reach it (to well under a millimetre), and report the residuals of the converged fit. It fails on `master` at the 1 m case, as above.

Found while implementing #65 (weighting the solve by measurement uncertainty), where the refinement solve always starts a little away from the weighted optimum and so hit this on every epoch; that work will stack on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)