### PR TITLE
feat!: weight the least-squares solve by measurement uncertainty (C/N₀ + elevation)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,6 +38,7 @@ GNSSSignals = "3.3"
 Geodesy = "0.5, 1.0"
 LinearAlgebra = "1"
 LsqFit = "0.12, 0.13, 0.14, 0.15, 0.16"
+Random = "1"
 StaticArrays = "1"
 Test = "1"
 Tracking = "3, 4, 5, 6"
@@ -49,8 +50,9 @@ Acquisition = "d4bbf60b-102b-5ffb-8f97-a7ea5817e69f"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracking = "10b2438b-ffd4-5096-aa58-44041d5c8f3b"
 
 [targets]
-test = ["Acquisition", "Aqua", "CodecZlib", "Downloads", "Test", "Tracking"]
+test = ["Acquisition", "Aqua", "CodecZlib", "Downloads", "Random", "Test", "Tracking"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Calculates position and time by using GNSS data
 * Estimation of user position and time
 * Calculates satellite position
 * Precision estimation (GDOP)
+* Weighted least squares: satellites reporting a C/N₀ are weighted by their measurement
+  uncertainty, and the solution carries a formal accuracy in metres
 
 ## Preparing
 
@@ -22,6 +24,7 @@ pkg> add PositionVelocityTime
 Decoded data and code phase of satellite must be combined in the provided `SatelliteState` struct. 
 ```julia
 using PositionVelocityTime, GNSSSignals, GNSSDecoder
+using Unitful: dBHz
 # decode satellite
 gpsl1 = GPSL1CA()
 sat_state = SatelliteState(
@@ -29,15 +32,23 @@ sat_state = SatelliteState(
     system = gpsl1,
     code_phase = code_phase,
     carrier_doppler = carrier_doppler,
-    carrier_phase = carrier_phase # optional, in radians
+    carrier_phase = carrier_phase, # optional, in radians
+    cn0 = 42.0dBHz                 # optional, enables weighted least squares
 )
 ```
 The declaration of `carrier_phase` is optional due to its small effect on the user position.
 `code_phase` is in chips and `carrier_phase` in radians, matching `Tracking`'s
 `get_code_phase` and `get_carrier_phase`.
 
+`cn0` is optional as well. Supplying it lets `calc_pvt` weight each satellite by the
+measurement uncertainty its C/N₀ and elevation imply, instead of treating a marginal
+satellite as being as precise as a strong one — code noise is roughly an order of
+magnitude worse at 30 dBHz than at 45 dBHz. Pass `pseudorange_variance` instead (e.g.
+`(3.0m)^2`) to supply your own error model. With neither, the solve is the plain
+unweighted one.
+
 Alternatively, a `Tracking.TrackedSat` can be passed to `SatelliteState` instead of
-`code_phase`, `carrier_doppler` and `carrier_phase` — `tracked_sat` below is what
+`code_phase`, `carrier_doppler`, `carrier_phase` and `cn0` — `tracked_sat` below is what
 `Tracking.get_sat_state` returns for a tracked satellite:
 ```julia
 using Tracking
@@ -56,3 +67,8 @@ provides a complete position calculation. A fix needs at least 4 healthy, fully 
 satellites (more for a multi-GNSS or multi-band set); when the epoch cannot be solved,
 the previous solution is returned unchanged instead of an error, so a receiver can pass
 whatever it currently tracks.
+
+The solution reports the geometry as `pvt.dop` (dilution of precision, purely geometric)
+and, alongside it, `pvt.accuracy` — the formal 1σ accuracy in metres (horizontal,
+vertical, 3D and clock) with the measurement uncertainties folded in. Each satellite's
+`pvt.sats` entry carries the σ it was weighted by next to its post-fit residual.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -38,10 +38,27 @@ PositionVelocityTime.NTCMGParams
 PositionVelocityTime._elevation_azimuth
 ```
 
+## Measurement Uncertainty and Weighting
+
+[`calc_pvt`](@ref) solves a weighted least squares whenever a satellite reports its
+C/N₀ (or an explicit variance) on its [`SatelliteState`](@ref); these are the models
+that turn that report into a weight, and the accuracy that comes out of the weighted
+solve.
+
+```@docs
+PositionVelocityTime.pseudorange_variance
+PositionVelocityTime.range_rate_variance
+PositionVelocityTime.has_measurement_uncertainty
+PositionVelocityTime.predict_pseudorange_variances
+PositionVelocityTime.FormalAccuracy
+PositionVelocityTime.calc_formal_accuracy
+```
+
 ## Dilution of Precision
 
 The DOP values are read from the `dop` field of a [`PVTSolution`](@ref), e.g.
-`pvt.dop.GDOP`.
+`pvt.dop.GDOP`. They describe the geometry alone; the measurement uncertainty enters the
+separate [`PositionVelocityTime.FormalAccuracy`](@ref) above.
 
 ```@docs
 PositionVelocityTime.DOP

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,6 +8,9 @@ Calculates position, velocity, and time from GNSS satellite measurements.
 - Satellite position and velocity calculation from orbital parameters (LNAV and
   CNAV/CNAV-2 quasi-Keplerian ephemerides)
 - Dilution of Precision (DOP) computation
+- Weighted least squares from the reported C/N₀ and the satellite elevation, so a
+  marginal satellite contributes its geometry without dragging the fix, plus a formal
+  accuracy in metres alongside the (purely geometric) DOP
 - Support for GPS (L1 C/A, L2C, L5, L1C) and Galileo (E1B, E5a), including combined
   multi-GNSS solutions. Each measurement is one satellite-band pseudorange; the
   group-delay/ISC correction is selected by the signal the range was generated on
@@ -27,6 +30,7 @@ Decoded data and code phase of a satellite must be combined in the [`SatelliteSt
 
 ```julia
 using PositionVelocityTime, GNSSSignals, GNSSDecoder
+using Unitful: dBHz
 
 gpsl1 = GPSL1CA()
 sat_state = SatelliteState(
@@ -35,15 +39,23 @@ sat_state = SatelliteState(
     code_phase = code_phase,
     carrier_doppler = carrier_doppler,
     carrier_phase = carrier_phase,  # optional, in radians
+    cn0 = 42.0dBHz,                 # optional, enables weighted least squares
 )
 ```
 
 `code_phase` is in chips and `carrier_phase` in radians, matching `Tracking`'s
 `get_code_phase` and `get_carrier_phase`.
 
+`cn0` is optional too, and matches `Tracking.estimate_cn0`. Supplying it lets
+[`calc_pvt`](@ref) weight each satellite by the measurement uncertainty its C/N₀ and
+elevation imply (see [`PositionVelocityTime.pseudorange_variance`](@ref)) rather than
+treating a marginal satellite as being as precise as a strong one. Supply
+`pseudorange_variance` (e.g. `(3.0m)^2`) instead to use your own error model; with
+neither, the solve is the plain unweighted one and behaves exactly as before.
+
 Alternatively, pass a `Tracking.TrackedSat` directly — `tracked_sat` is what
 `Tracking.get_sat_state` returns for a tracked satellite, and the code phase, carrier
-Doppler, and carrier phase are read off it:
+Doppler, carrier phase, and C/N₀ are read off it:
 
 ```julia
 using Tracking
@@ -67,3 +79,19 @@ If too few healthy satellites are tracked to solve the constellation — or the 
 turns out to be degenerate — [`calc_pvt`](@ref) returns the `prev_pvt` it was given (the
 origin solution by default) rather than throwing, so a receiver can hand it whatever it
 currently tracks each epoch and carry the last solution forward.
+
+## Solution quality
+
+Two quantities describe how good a fix is, and they are deliberately separate:
+
+- `pvt.dop` ([`PositionVelocityTime.DOP`](@ref)) is the **geometry** alone,
+  `(HᵀH)⁻¹` — unitless, and unchanged by measurement weighting, so it means what every
+  other receiver means by GDOP/PDOP/HDOP/VDOP/TDOP.
+- `pvt.accuracy` ([`PositionVelocityTime.FormalAccuracy`](@ref)) is the **formal 1σ
+  accuracy in metres**, `(HᵀWH)⁻¹`, i.e. the geometry with the a-priori measurement
+  uncertainties folded in. With no uncertainty reported it reduces to DOP × a nominal
+  UERE.
+
+Per satellite, `pvt.sats` reports the post-fit residual (raw metres, weighted or not)
+and the σ that satellite was weighted by, whose ratio is the normalised residual used
+for fault detection.

--- a/ext/PositionVelocityTimeTrackingExt.jl
+++ b/ext/PositionVelocityTimeTrackingExt.jl
@@ -3,20 +3,39 @@ module PositionVelocityTimeTrackingExt
 using PositionVelocityTime: PositionVelocityTime, SatelliteState
 using GNSSDecoder: GNSSDecoderState
 using GNSSSignals: AbstractGNSSSignal
-using Tracking: Tracking, get_code_phase, get_carrier_doppler, get_carrier_phase
+using Tracking:
+    Tracking, get_code_phase, get_carrier_doppler, get_carrier_phase, estimate_cn0
 
 function PositionVelocityTime.SatelliteState(
     decoder::GNSSDecoderState,
     system::AbstractGNSSSignal,
-    sat_state::Tracking.TrackedSat,
+    sat_state::Tracking.TrackedSat;
+    cn0 = tracked_cn0(sat_state, system),
+    pseudorange_variance = nothing,
 )
-    SatelliteState(
+    SatelliteState(;
         decoder,
         system,
-        get_code_phase(sat_state),
-        get_carrier_doppler(sat_state),
-        get_carrier_phase(sat_state),
+        code_phase = get_code_phase(sat_state),
+        carrier_doppler = get_carrier_doppler(sat_state),
+        carrier_phase = get_carrier_phase(sat_state),
+        cn0,
+        pseudorange_variance,
     )
+end
+
+# C/N₀ of the signal the pseudorange was generated on, so a tracking receiver gets the
+# weighted solve without wiring anything up (pass `cn0` explicitly to override, or
+# `cn0 = nothing` to opt out). `estimate_cn0` selects a signal of a multi-signal
+# satellite by type, which is ambiguous when the satellite is tracked on two signals of
+# that type and an error when it is tracked on none; neither is worth failing a fix
+# over, so both fall back to the satellite's estimator-driver signal (`signals[1]`).
+# A satellite whose estimator has not integrated a prompt yet reports `0.0dBHz`, which
+# the variance model treats as "not reported" rather than as an unusably weak signal.
+function tracked_cn0(sat_state::Tracking.TrackedSat, system::AbstractGNSSSignal)
+    signals = Tracking.get_signals(sat_state)
+    matching = count(sig -> Tracking.get_signal(sig) isa typeof(system), signals)
+    estimate_cn0(sat_state, matching == 1 ? typeof(system) : 1)
 end
 
 end

--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -11,7 +11,7 @@ using CoordinateTransformations,
     Unitful,
     Dates
 
-using Unitful: s, Hz, m, °, ustrip
+using Unitful: s, Hz, m, °, dBHz, ustrip, uconvert
 using Dictionaries: Dictionary
 
 export calc_pvt,
@@ -111,15 +111,26 @@ Combines the GNSS decoder state with code and carrier phase measurements for a s
 - `carrier_doppler`: Carrier Doppler frequency in Hz
 - `carrier_phase::CP`: Carrier phase measurement in radians, matching
   `Tracking.get_carrier_phase` (default: `0.0`)
+- `cn0::Union{Nothing,typeof(1.0dBHz)}`: Carrier-to-noise-density ratio of this
+  measurement, e.g. `42.0dBHz`, matching `Tracking.estimate_cn0` (default: `nothing`,
+  "not reported"). Supplying it lets [`calc_pvt`](@ref) weight this satellite by its
+  measurement uncertainty instead of treating every satellite as equally precise —
+  see [`pseudorange_variance`](@ref). A non-positive level is treated as not
+  reported, as is a non-finite one.
+- `pseudorange_variance::Union{Nothing,typeof(1.0m^2)}`: Optional explicit a-priori
+  variance of this pseudorange, e.g. `(3.0m)^2`, for a caller that owns its own error
+  model. When given it replaces the modeled variance entirely — C/N₀ and elevation
+  are then not consulted for this satellite's position weight (default: `nothing`).
 
 # Constructors
-    SatelliteState(; decoder, system, code_phase, carrier_doppler, carrier_phase=0.0)
-    SatelliteState(decoder, system, sat_state)
+    SatelliteState(; decoder, system, code_phase, carrier_doppler, carrier_phase=0.0,
+                   cn0=nothing, pseudorange_variance=nothing)
+    SatelliteState(decoder, system, sat_state; cn0=…, pseudorange_variance=nothing)
 
-The second constructor extracts code phase, carrier Doppler, and carrier phase from a
-`Tracking` satellite state (`Tracking.TrackedSat`). It is provided by a package extension
-that is loaded automatically once `Tracking` is available, so `Tracking` is only a weak
-dependency of this package.
+The second constructor extracts code phase, carrier Doppler, carrier phase and C/N₀
+from a `Tracking` satellite state (`Tracking.TrackedSat`). It is provided by a package
+extension that is loaded automatically once `Tracking` is available, so `Tracking` is
+only a weak dependency of this package.
 """
 @kwdef struct SatelliteState{CP<:Real,D<:GNSSDecoder.GNSSDecoderState,S<:AbstractGNSSSignal}
     decoder::D
@@ -127,6 +138,8 @@ dependency of this package.
     code_phase::CP
     carrier_doppler::typeof(1.0Hz)
     carrier_phase::CP = 0.0
+    cn0::Union{Nothing,typeof(1.0dBHz)} = nothing
+    pseudorange_variance::Union{Nothing,typeof(1.0m^2)} = nothing
 end
 
 """
@@ -151,6 +164,41 @@ struct DOP
 end
 
 """
+    FormalAccuracy
+
+Formal (1σ) accuracy of a [`PVTSolution`](@ref) in metres: the square-rooted diagonal
+of the least-squares parameter covariance `(HᵀWH)⁻¹`, with the position block rotated
+into the local East-North-Up frame — see [`calc_formal_accuracy`](@ref).
+
+This is the *weighted* counterpart of [`DOP`](@ref) and deliberately a separate
+output. DOP is by definition a purely geometric quantity, `(HᵀH)⁻¹`, and stays that
+way whether or not the epoch was weighted, so it keeps meaning what every receiver
+and textbook means by it; the accuracy here folds in the a-priori measurement
+uncertainty (see [`pseudorange_variance`](@ref)) and so carries units. When no
+satellite reports any uncertainty the weights are uniform and this reduces to the
+familiar DOP × nominal-UERE product.
+
+It is *formal*: it propagates the assumed measurement variances through the geometry
+and says nothing about errors the model does not describe (multipath beyond the model,
+an undetected faulty satellite, broadcast-ephemeris error).
+
+# Fields
+- `horizontal::typeof(1.0m)`: Horizontal 1σ (East² + North²), i.e. the classic HDRMS.
+- `vertical::typeof(1.0m)`: Vertical (Up) 1σ.
+- `position::typeof(1.0m)`: 3D position 1σ (trace of the position block; frame
+  independent, so `≈ hypot(horizontal, vertical)`).
+- `time::typeof(1.0m)`: 1σ of the reported receiver clock bias, as a range (metres);
+  divide by the speed of light for seconds. This is the clock of `reference_system`,
+  matching `DOP.TDOP`.
+"""
+struct FormalAccuracy
+    horizontal::typeof(1.0m)
+    vertical::typeof(1.0m)
+    position::typeof(1.0m)
+    time::typeof(1.0m)
+end
+
+"""
     SatInfo
 
 Per-satellite information attached to a [`PVTSolution`](@ref) (one entry per
@@ -161,18 +209,27 @@ satellite used in the fix).
 - `time::Float64`: Satellite transmit time (system time of week, seconds).
 - `residual::typeof(1.0m)`: Post-fit least-squares pseudorange residual (metres) — the
   modeled minus the (atmosphere-corrected) measured pseudorange. A per-satellite
-  fit-quality / outlier indicator.
+  fit-quality / outlier indicator. This is the **raw** residual in metres, not the
+  weight-normalised one, so it keeps the same meaning whether or not the epoch was
+  weighted; divide it by `pseudorange_sigma` for the normalised residual that fault
+  detection (RAIM) works with.
 - `rate_residual::typeof(1.0m/s)`: Post-fit least-squares range-rate residual (metres per
   second) — the modeled minus the measured range rate of the carrier-Doppler velocity and
   clock-drift solve. The rate-domain counterpart of `residual`: it flags a satellite whose
   Doppler disagrees with the velocity fix (cycle slips, dynamics) independently of its
   pseudorange.
+- `pseudorange_sigma::typeof(1.0m)`: A-priori standard deviation (metres) this
+  satellite's pseudorange was weighted by — its [`pseudorange_variance`](@ref),
+  square-rooted. When no satellite of the epoch reported any uncertainty the solve is
+  unweighted and this is the nominal UERE assumed for the reported accuracy, the same
+  value for every satellite.
 """
 struct SatInfo
     position::ECEF
     time::Float64
     residual::typeof(1.0m)
     rate_residual::typeof(1.0m/s)
+    pseudorange_sigma::typeof(1.0m)
 end
 
 """
@@ -215,10 +272,15 @@ Complete Position, Velocity, and Time solution from GNSS measurements.
   other systems' biases are `time_correction + inter_system_biases[system]`.
 - `time::Union{TAIEpoch{Float64}, Nothing}`: Estimated time as a TAI epoch
 - `relative_clock_drift::Float64`: Relative receiver clock drift (dimensionless)
-- `dop::Union{DOP, Nothing}`: Dilution of precision values
+- `dop::Union{DOP, Nothing}`: Dilution of precision values — purely geometric, and
+  unaffected by measurement weighting (see [`FormalAccuracy`](@ref))
+- `accuracy::Union{FormalAccuracy, Nothing}`: Formal 1σ accuracy of this solution in
+  metres (horizontal, vertical, 3D and clock), from the least-squares covariance with
+  the a-priori measurement variances folded in. See [`FormalAccuracy`](@ref)
 - `sats::Dictionary{Tuple{Symbol, Int}, SatInfo}`: Maps `(signal, PRN)` to satellite
-  info — position, transmit time, and the post-fit pseudorange and range-rate
-  residuals (see [`SatInfo`](@ref)). The signal tag (e.g. `:GPSL1CA`,
+  info — position, transmit time, the post-fit pseudorange and range-rate residuals, and
+  the a-priori σ the pseudorange was weighted by (see [`SatInfo`](@ref)). The signal tag
+  (e.g. `:GPSL1CA`,
   `:GalileoE1B`; see `get_signal_id`) keeps the
   same PRN apart both across constellations (GPS PRN 5 vs Galileo E05) and across
   signals of one constellation (a satellite tracked on GPS L1 C/A and L5 yields two
@@ -257,6 +319,7 @@ Complete Position, Velocity, and Time solution from GNSS measurements.
     time::Union{TAIEpoch{Float64},Nothing} = nothing
     relative_clock_drift::Float64 = 0
     dop::Union{DOP,Nothing} = nothing
+    accuracy::Union{FormalAccuracy,Nothing} = nothing
     sats::Dictionary{Tuple{Symbol,Int},SatInfo} = Dictionary{Tuple{Symbol,Int},SatInfo}()
     reference_system::Union{GNSSSignals.TimeSystem,Nothing} = nothing
     inter_system_biases::Dict{GNSSSignals.TimeSystem,typeof(1.0m)} =
@@ -592,6 +655,18 @@ Unless disabled via `enable_tropospheric_correction`, the tropospheric delay is
 corrected with the blind Saastamoinen model (no broadcast coefficients needed).
 See [`tropospheric_delay`](@ref).
 
+Satellites are weighted by their measurement uncertainty rather than treated as equally
+precise, as soon as any of them reports a `cn0` (or an explicit `pseudorange_variance`)
+on its [`SatelliteState`](@ref): the position solve then minimises `Σ (ρ̂ⱼ − ρⱼ)²/σ²ⱼ`
+with σ from the C/N₀- and elevation-dependent model in [`pseudorange_variance`](@ref),
+and the velocity solve is weighted by the Doppler's own
+[`range_rate_variance`](@ref). This matters because code noise is a strong function of
+C/N₀ — an order of magnitude between a 30 dBHz and a 45 dBHz satellite — so a marginal
+satellite can otherwise drag a fix that the strong ones would have pinned down. Reported
+per satellite as `SatInfo.pseudorange_sigma`, and summarised as the solution's formal
+[`FormalAccuracy`](@ref). When no satellite reports either, the solve is the ordinary
+least-squares one it has always been.
+
 # Arguments
 - `states`: Vector of [`SatelliteState`](@ref) for observed satellites. Each
   (signal, PRN) pair must appear at most once — a receiver produces one
@@ -615,9 +690,9 @@ See [`tropospheric_delay`](@ref).
   tropospheric correction. Set to `false` to skip it.
 
 # Returns
-A [`PVTSolution`](@ref) containing position, velocity, time, DOP values, and
-satellite information. Returns `prev_pvt` if the epoch cannot be solved: too few healthy
-satellites to solve the constellation (including the GGTO fallback and the
+A [`PVTSolution`](@ref) containing position, velocity, time, DOP values, formal accuracy,
+and satellite information. Returns `prev_pvt` if the epoch cannot be solved: too few
+healthy satellites to solve the constellation (including the GGTO fallback and the
 distinct-satellite condition — a satellite tracked on several bands supplies one line of
 sight, so measurements alone are not enough), a geometry whose solved design matrix is
 rank deficient (reported as a negative GDOP). None of these throw, so a receiver can pass
@@ -726,32 +801,51 @@ function calc_pvt(
     correct_atmosphere =
         !isnothing(ionospheric_correction) || enable_tropospheric_correction
 
-    ξ, residuals = if iszero(prev_ξ)
-        # Cold start: no prior position, and the Klobuchar model is undefined near
-        # the geocenter, so first obtain an approximate fix from an uncorrected
-        # solve, then re-solve once with the delay-corrected pseudoranges (only if
-        # there is anything to correct, so the uncorrected case stays a single solve).
-        ξ_uncorrected, resid_uncorrected =
-            user_position(sat_positions_mat, pseudo_ranges, bias_columns, prev_ξ)
-        if correct_atmosphere
-            atmospheric_delays = predict_atmospheric_delays(
-                ξ_uncorrected, healthy_states, sat_positions, ionospheric_correction,
-                reference_time, enable_tropospheric_correction)
-            user_position(
-                sat_positions_mat, pseudo_ranges .- atmospheric_delays, bias_columns, ξ_uncorrected)
-        else
-            (ξ_uncorrected, resid_uncorrected)
-        end
-    else
-        # Warm start: predict the delays from the previous (already metre-accurate)
-        # position before solving, so ξ never needs a post-solve correction. With no
-        # active correction, solve directly on the raw pseudoranges.
-        corrected_ranges =
+    # Weight the solve by measurement uncertainty as soon as any satellite carries the
+    # information for it (a C/N₀ or an explicit variance); with none, every weight would
+    # be the same and the epoch is solved by ordinary least squares exactly as before.
+    # See `has_measurement_uncertainty` and [`pseudorange_variance`](@ref).
+    weighted = any(has_measurement_uncertainty, healthy_states)
+
+    # One solve about the measurement model evaluated at `ξ_reference`: both the
+    # atmospheric delays and the a-priori variances depend on position only through the
+    # satellite elevations, so a metre-accurate reference position is enough for either
+    # (see `predict_atmospheric_delays` / `predict_pseudorange_variances`) and neither
+    # needs iterating to convergence. Returns the solved state, the raw (metre) residuals
+    # and the variances the weights came from, which are reported per satellite and set
+    # the scale of the formal accuracy below.
+    function solve_about(ξ_reference)
+        ranges =
             correct_atmosphere ?
             pseudo_ranges .- predict_atmospheric_delays(
-                prev_ξ, healthy_states, sat_positions, ionospheric_correction,
+                ξ_reference, healthy_states, sat_positions, ionospheric_correction,
                 reference_time, enable_tropospheric_correction) : pseudo_ranges
-        user_position(sat_positions_mat, corrected_ranges, bias_columns, prev_ξ)
+        variances =
+            weighted ?
+            predict_pseudorange_variances(ξ_reference, healthy_states, sat_positions) :
+            fill(_NOMINAL_PSEUDORANGE_SIGMA^2, num_sats)
+        ξ_solved, residuals = user_position(
+            sat_positions_mat, ranges, bias_columns, ξ_reference;
+            weights = weighted ? inv.(variances) : nothing)
+        (ξ_solved, residuals, variances)
+    end
+
+    ξ, residuals, pseudorange_variances = if iszero(prev_ξ)
+        # Cold start: no prior position, and both the Klobuchar model and the elevation
+        # part of the variance model need one, so first obtain an approximate fix from an
+        # uncorrected, unweighted solve, then re-solve once about it (only if there is
+        # anything to correct or to weight, so the plain case stays a single solve).
+        ξ_uncorrected, resid_uncorrected =
+            user_position(sat_positions_mat, pseudo_ranges, bias_columns, prev_ξ)
+        if correct_atmosphere || weighted
+            solve_about(ξ_uncorrected)
+        else
+            (ξ_uncorrected, resid_uncorrected, fill(_NOMINAL_PSEUDORANGE_SIGMA^2, num_sats))
+        end
+    else
+        # Warm start: the previous (already metre-accurate) position is the reference, so
+        # ξ never needs a post-solve correction and one solve suffices.
+        solve_about(prev_ξ)
     end
     H = calc_H(sat_positions_mat, ξ, bias_columns)
     position = ECEF(ξ[1], ξ[2], ξ[3])
@@ -767,8 +861,18 @@ function calc_pvt(
     dop = calc_DOP(H, position, primary_clock_index)
     dop.GDOP < 0 && return prev_pvt
 
+    # The DOP stays the purely geometric `(HᵀH)⁻¹`; the formal accuracy is the separate,
+    # metre-valued `(HᵀWH)⁻¹` of the solve that actually ran (see `FormalAccuracy`). Its
+    # positive definiteness follows from the DOP check just made, weights being positive.
+    accuracy = calc_formal_accuracy(H, pseudorange_variances, position, primary_clock_index)
+
+    # The velocity solve is weighted from the Doppler's own variance model — carrier-loop
+    # noise, not code-loop noise — and left unweighted when no C/N₀ was reported.
+    range_rate_weights =
+        weighted ? inv.(map(range_rate_variance, healthy_states)) : nothing
     user_velocity_and_clock_drift, rate_residuals = calc_user_velocity_and_clock_drift(
-        sat_positions_and_velocities, healthy_states, times, H)
+        sat_positions_and_velocities, healthy_states, times, H;
+        weights = range_rate_weights)
     velocity = ECEF(
         user_velocity_and_clock_drift[1],
         user_velocity_and_clock_drift[2],
@@ -790,7 +894,8 @@ function calc_pvt(
         corrected_reference_time - floor(Int, corrected_reference_time),
     )
 
-    sat_infos = SatInfo.(sat_positions, times, residuals .* m, rate_residuals .* (m/s))
+    sat_infos = SatInfo.(sat_positions, times, residuals .* m, rate_residuals .* (m/s),
+        sqrt.(pseudorange_variances) .* m)
 
     # Inter-system biases relative to the reference (primary) system's clock, in
     # meters. The reference is omitted (its bias is `time_correction`); for a
@@ -827,6 +932,7 @@ function calc_pvt(
         time,
         relative_clock_drift,
         dop,
+        accuracy,
         Dictionary(healthy_sat_keys, sat_infos),
         primary_system,
         inter_system_biases,
@@ -903,4 +1009,5 @@ include("sat_time.jl")
 include("sat_position.jl")
 include("ionosphere.jl")
 include("troposphere.jl")
+include("measurement_variance.jl")
 end

--- a/src/measurement_variance.jl
+++ b/src/measurement_variance.jl
@@ -1,0 +1,226 @@
+# ===========================================================================
+#  A-priori measurement uncertainty — C/N₀ and elevation → variance
+#
+#  Ordinary least squares gives every satellite the same say in the fix, which is
+#  only right when every pseudorange carries the same noise. It does not: code
+#  measurement noise is a strong function of C/N₀ (the tracking loops' thermal
+#  jitter), and the residual model errors — multipath and whatever the atmospheric
+#  models leave behind — grow towards the horizon. A marginal satellite therefore
+#  arrives with roughly an order of magnitude more noise than a strong one, and with
+#  five or six satellites it can visibly drag a fix the others would have pinned down.
+#
+#  The standard remedy is weighted least squares with *a-priori* weights `w = 1/σ²`
+#  from a variance model, which is what this file provides: one variance for the
+#  pseudorange (the position solve) and one for the range rate (the velocity solve),
+#  since code and carrier noise follow different loops. The weights are a-priori by
+#  design — residual-based reweighting (IRLS) would be the wrong tool here, because a
+#  four-to-six-satellite epoch against 4+ unknowns has barely any degrees of freedom,
+#  so its residuals are shaped by the geometry and by the fit itself rather than by
+#  measurement quality, and it would happily down-weight a perfectly good satellite.
+#
+#  Only the *ratios* of the variances affect the estimate; their absolute scale shows
+#  up solely in the reported formal accuracy (see [`FormalAccuracy`](@ref)).
+# ===========================================================================
+
+# Non-thermal part of the user-equivalent range error: residual satellite
+# ephemeris/clock error plus what the ionospheric and tropospheric models leave
+# behind, as a single elevation-independent floor. This is the term that keeps the
+# weights finite and the weight spread bounded when one satellite reports a very high
+# C/N₀ — a strong satellite is not infinitely precise, it is limited by this.
+const _RESIDUAL_UERE_SIGMA = 1.5  # m
+
+# Elevation-mapped term `a/sin(El)`: multipath and residual atmosphere, both of which
+# grow along the lengthening slant path towards the horizon. `a` is the zenith value,
+# so this contributes 0.5 m straight up and ~5.7 m at 5° elevation. The RTKLIB
+# baseline model has the same `a²+b²/sin²El` shape (`varerr` in `pntpos.c`), with the
+# code-noise term there scaled up from the carrier-phase one instead of derived from
+# C/N₀ as below.
+const _ELEVATION_SIGMA = 0.5  # m
+
+# Code-loop parameters behind the C/N₀ term: a 1 Hz single-sided noise bandwidth and a
+# one-chip early–late spacing, the conventional reference configuration for the
+# coherent-DLL thermal-jitter expression (Kaplan & Hegarty ch. 5, Groves ch. 9)
+#
+#     σ_code = (c / f_chip) · √(B_n · d / 2) · 10^(−CN0[dBHz]/20)   metres
+#
+# whose square is the `b²·10^(−CN0/10)` term of the standard model — with `b` derived
+# per signal from its chipping rate rather than tuned, so a wider-band signal is
+# credited its narrower correlation peak automatically. For GPS L1 C/A
+# (`c/f_chip` ≈ 293 m) this gives ≈ 1.2 m at 45 dBHz and ≈ 6.5 m at 30 dBHz, the
+# order-of-magnitude spread that motivates weighting at all. A receiver whose loops
+# differ can bypass the model with `SatelliteState.pseudorange_variance`.
+const _CODE_LOOP_BANDWIDTH = 1.0   # Hz
+const _EARLY_LATE_SPACING = 1.0    # chips
+
+# Robustness floor and ceiling on σ. A C/N₀ estimate inherits its estimator's bias and
+# spread, and the elevation term diverges towards the horizon, so σ is clamped: no
+# single reading can hand one satellite near-infinite leverage (the floor), and a
+# satellite whose C/N₀ reads absurdly low is heavily down-weighted but never fully
+# discarded (the ceiling). The bounds also bound the conditioning cost of weighting:
+# `cond(√W·H) ≤ (σ_max/σ_min)·cond(H)`, i.e. at most two orders of magnitude here.
+const _PSEUDORANGE_SIGMA_BOUNDS = (0.5, 50.0)  # m
+
+# Uniform σ assumed when *no* satellite carries any uncertainty information. The solve
+# is then plain OLS (uniform weights change nothing), so this value never moves the
+# estimate — it only sets the scale of the reported [`FormalAccuracy`](@ref), which in
+# that case is the familiar "DOP × UERE". 5 m is a nominal single-frequency UERE.
+const _NOMINAL_PSEUDORANGE_SIGMA = 5.0  # m
+
+# Range-rate (Doppler) model, for the velocity/clock-drift solve. Doppler noise follows
+# the carrier loop, not the DLL, so it gets its own variance: the coherent FLL
+# thermal-jitter expression
+#
+#     σ_rangerate = λ / (2π·T) · √(4·B_n / (C/N₀))   metres/second
+#
+# with a 1 Hz loop bandwidth and a 20 ms coherent integration (one GPS L1 C/A data
+# symbol — the longest integration available before bit sync is exploited, and the
+# common choice once it is). For L1 that is ≈ 0.10 m/s at 30 dBHz and ≈ 0.02 m/s at
+# 45 dBHz. The floor stands for what is left after the loop: satellite-velocity and
+# clock-drift model error.
+const _RANGE_RATE_SIGMA_FLOOR = 0.01     # m/s
+const _CARRIER_LOOP_BANDWIDTH = 1.0      # Hz
+const _CARRIER_INTEGRATION_TIME = 0.02   # s
+const _RANGE_RATE_SIGMA_BOUNDS = (0.005, 5.0)  # m/s
+
+"""
+    _is_usable_cn0(cn0) -> Bool
+
+Whether `cn0` is a C/N₀ reading the variance models can use: present, finite and
+positive. `nothing` is the "not reported" case, and a non-positive level is not a
+plausible measurement of a satellite that is being tracked — `0.0dBHz` is in
+particular what `Tracking`'s moment-based estimator returns before it has integrated
+a single prompt — so both are treated as *unknown* rather than as an unusably weak
+signal, leaving the C/N₀ term out of the variance instead of driving it to the
+ceiling.
+"""
+_is_usable_cn0(::Nothing) = false
+_is_usable_cn0(cn0) = isfinite(ustrip(cn0)) && cn0 > 0.0dBHz
+
+"""
+    _linear_cn0(cn0) -> Float64
+
+The carrier-to-noise-density ratio as a linear ratio in Hz (e.g. `45.0dBHz` →
+`3.16e4`), the form the thermal-jitter expressions take it in. Unitful's
+logarithmic-unit conversion does the `10^(CN0/10)` itself.
+"""
+_linear_cn0(cn0) = ustrip(Hz, uconvert(Hz, cn0))
+
+"""
+    has_measurement_uncertainty(state::SatelliteState) -> Bool
+
+Whether `state` carries the information needed to weight it: an explicit
+`pseudorange_variance`, or a usable `cn0` (present, finite and positive — see
+`_is_usable_cn0`).
+[`calc_pvt`](@ref) weights an epoch's solve only when at least one satellite does;
+with none it stays ordinary least squares, so a caller that reports neither keeps
+exactly the unweighted behaviour.
+"""
+has_measurement_uncertainty(state::SatelliteState) =
+    !isnothing(state.pseudorange_variance) || _is_usable_cn0(state.cn0)
+
+"""
+    pseudorange_variance(system, cn0, elevation) -> Float64
+    pseudorange_variance(state::SatelliteState, elevation) -> Float64
+
+A-priori variance of a pseudorange measurement in m², the reciprocal of its
+least-squares weight. `system` is the ranging signal (its chipping rate sets the
+code-noise scale), `cn0` its carrier-to-noise-density ratio as a `dBHz` level (or
+`nothing` when not reported) and `elevation` the satellite elevation in radians (or
+`nothing` when no position is available yet, as at a cold start):
+
+    σ² = σ²_UERE + (a / sin El)² + (c/f_chip)² · (B_n·d/2) · 10^(−CN0/10)
+
+The three terms are the residual non-thermal UERE, the elevation-mapped
+multipath/atmosphere term, and the code-loop thermal jitter; each of the latter two
+is dropped when its input is `nothing`. σ is clamped to
+$(_PSEUDORANGE_SIGMA_BOUNDS) m, so no single reading can dominate the fix and none is
+silently discarded. Elevations below `_LOW_ELEVATION_THRESHOLD` (≈ 2.87°, including
+negative ones) are treated as that bound — the same guard the tropospheric mapping
+uses, and the reason a grazing satellite ends up de-weighted rather than trusted.
+
+The `SatelliteState` form is what [`calc_pvt`](@ref) calls: it returns the state's
+own `pseudorange_variance` when the caller supplied one (the model is then bypassed
+entirely, units stripped to m²) and otherwise evaluates the model above. A supplied
+variance is clamped to the same bounds, so a degenerate one (zero, negative, `NaN`)
+cannot turn into an infinite weight and take over the fix.
+
+$SIGNATURES
+"""
+function pseudorange_variance(system, cn0, elevation)
+    σ² = _RESIDUAL_UERE_SIGMA^2
+    if !isnothing(elevation)
+        sin_el = sin(max(elevation, _LOW_ELEVATION_THRESHOLD))
+        σ² += (_ELEVATION_SIGMA / sin_el)^2
+    end
+    if _is_usable_cn0(cn0)
+        chip_length = SPEEDOFLIGHT / ustrip(Hz, get_code_frequency(system))
+        σ² +=
+            chip_length^2 * _EARLY_LATE_SPACING * _CODE_LOOP_BANDWIDTH / 2 /
+            _linear_cn0(cn0)
+    end
+    _bound_pseudorange_variance(σ²)
+end
+
+pseudorange_variance(state::SatelliteState, elevation) =
+    isnothing(state.pseudorange_variance) ?
+    pseudorange_variance(state.system, state.cn0, elevation) :
+    _bound_pseudorange_variance(ustrip(m^2, state.pseudorange_variance))
+
+# `clamp` on the variance rather than on σ, and `NaN`-safe: `clamp` would pass a `NaN`
+# straight through (every comparison is false), and a `NaN` weight poisons the whole
+# solve, so map it to the ceiling — the treatment a meaningless reading deserves.
+_bound_pseudorange_variance(σ²) =
+    isnan(σ²) ? _PSEUDORANGE_SIGMA_BOUNDS[2]^2 :
+    clamp(σ², _PSEUDORANGE_SIGMA_BOUNDS[1]^2, _PSEUDORANGE_SIGMA_BOUNDS[2]^2)
+
+"""
+    range_rate_variance(system, cn0) -> Float64
+    range_rate_variance(state::SatelliteState) -> Float64
+
+A-priori variance of a Doppler-derived range-rate measurement in (m/s)², the
+reciprocal of its weight in the velocity and clock-drift solve:
+
+    σ² = σ²_floor + (λ / 2πT)² · 4·B_n · 10^(−CN0/10)
+
+`λ` is the carrier wavelength of `system` and the C/N₀ term is the coherent
+frequency-loop thermal jitter (see the constants above); it is dropped when `cn0` is
+not usable, which leaves the variance uniform and the velocity solve unweighted. σ is
+clamped to $(_RANGE_RATE_SIGMA_BOUNDS) m/s, for the reasons given for the pseudorange
+bounds. Unlike the pseudorange, there is no per-satellite override field: the Doppler
+is not the measurement a caller is likely to have its own error model for.
+
+$SIGNATURES
+"""
+function range_rate_variance(system, cn0)
+    σ² = _RANGE_RATE_SIGMA_FLOOR^2
+    if _is_usable_cn0(cn0)
+        λ = SPEEDOFLIGHT / ustrip(Hz, get_center_frequency(system))
+        σ² +=
+            (λ / (2π * _CARRIER_INTEGRATION_TIME))^2 * 4 * _CARRIER_LOOP_BANDWIDTH /
+            _linear_cn0(cn0)
+    end
+    clamp(σ², _RANGE_RATE_SIGMA_BOUNDS[1]^2, _RANGE_RATE_SIGMA_BOUNDS[2]^2)
+end
+
+range_rate_variance(state::SatelliteState) = range_rate_variance(state.system, state.cn0)
+
+"""
+    predict_pseudorange_variances(ξ, states, sat_positions) -> Vector{Float64}
+
+Per-satellite pseudorange variances (m²) evaluated about the least-squares state
+vector `ξ = [x, y, z, tc₁, …]`, whose first three elements give the user ECEF
+position the elevations are taken from. Like `predict_atmospheric_delays`
+this only needs a metre-accurate position — ∂σ/∂position over that uncertainty is
+utterly negligible (a 15 m shift moves an elevation by ~1e-5°) — so one prediction
+about the previous or bootstrap solution serves the solve that follows, and the ENU
+transform is built once per epoch rather than per satellite.
+
+$SIGNATURES
+"""
+function predict_pseudorange_variances(ξ, states, sat_positions)
+    enu_from_ecef = ENUfromECEF(ECEF(ξ[1], ξ[2], ξ[3]), wgs84)
+    map(states, sat_positions) do state, sat_pos
+        elevation, _ = _elevation_azimuth(enu_from_ecef, sat_pos)
+        pseudorange_variance(state, elevation)
+    end
+end

--- a/src/user_position.jl
+++ b/src/user_position.jl
@@ -155,6 +155,28 @@ function positive_definite_cholesky(A::Symmetric)
 end
 
 """
+    ecef_to_enu_rotation(user_pos::ECEF) -> SMatrix{3,3,Float64}
+
+Rotation from ECEF to the local East-North-Up frame at `user_pos`, used to take the
+horizontal/vertical split of a position covariance in the user's tangent plane (both
+[`calc_DOP`](@ref) and [`calc_formal_accuracy`](@ref) need it). It matches Geodesy's
+`ENUfromECEF` convention (verified equal), and is built explicitly here as that is
+marginally cheaper than recovering it from the transform.
+
+$SIGNATURES
+"""
+function ecef_to_enu_rotation(user_pos::ECEF)
+    lla = LLAfromECEF(wgs84)(user_pos)
+    sφ, cφ = sincosd(lla.lat)
+    sλ, cλ = sincosd(lla.lon)
+    @SMatrix [
+        -sλ     cλ      0.0
+        -sφ*cλ  -sφ*sλ  cφ
+        cφ*cλ   cφ*sλ   sφ
+    ]
+end
+
+"""
 Calculates the dilution of precision for a given geometry matrix H
 
 `H_GEO` has `3 + num_clock_biases + num_ifb` columns (three position partials, one per
@@ -187,17 +209,7 @@ function calc_DOP(H_GEO, user_pos::ECEF, primary_clock_index = 1)
 
     # Rotate the ECEF position covariance into the local ENU (East, North, Up)
     # frame so the horizontal/vertical split is taken in the user's tangent plane.
-    # `R` is the ECEF→ENU rotation at the user position; it matches Geodesy's
-    # `ENUfromECEF` convention (verified equal), built explicitly here as it is
-    # marginally cheaper than recovering it from the transform.
-    lla = LLAfromECEF(wgs84)(user_pos)
-    sφ, cφ = sincosd(lla.lat)
-    sλ, cλ = sincosd(lla.lon)
-    R = @SMatrix [
-        -sλ     cλ      0.0
-        -sφ*cλ  -sφ*sλ  cφ
-        cφ*cλ   cφ*sλ   sφ
-    ]
+    R = ecef_to_enu_rotation(user_pos)
     D_enu = R * SMatrix{3,3}(@view D[1:3, 1:3]) * R'
 
     HDOP = sqrt(D_enu[1, 1] + D_enu[2, 2])   # horizontal dop (East² + North²)
@@ -207,6 +219,50 @@ function calc_DOP(H_GEO, user_pos::ECEF, primary_clock_index = 1)
     GDOP = sqrt(tr(D))                       # geometrical dop (all parameters)
 
     return DOP(GDOP, PDOP, VDOP, HDOP, TDOP)
+end
+
+"""
+    calc_formal_accuracy(H, variances, user_pos::ECEF, primary_clock_index = 1)
+
+Formal 1σ accuracy of a solve with design matrix `H` and per-satellite measurement
+`variances` (m²), as a [`FormalAccuracy`](@ref) — or `nothing` when `HᵀWH` is not
+positive definite, i.e. the geometry left a parameter unobservable (the same condition
+`calc_DOP` reports as a negative GDOP).
+
+`C = (HᵀWH)⁻¹`, `W = diag(1/σ²)`, is the covariance of the weighted least-squares
+estimate this package solves (and, for uniform variances, of the ordinary one).
+Because the variances carry metres, so does `C` — this is the *accuracy* counterpart
+of the unitless DOP, which stays purely geometric. The position block is rotated into
+the local ENU frame before the horizontal/vertical split, exactly as in `calc_DOP`;
+the 3D and clock entries are frame independent.
+
+Multiplying `W` by a constant scales `C` by its reciprocal, so a caller's overall
+uncertainty scale sets the reported accuracy while only the *ratios* of the variances
+affect the estimate itself.
+
+$SIGNATURES
+"""
+function calc_formal_accuracy(H, variances, user_pos::ECEF, primary_clock_index = 1)
+    # Weighting with strictly positive weights preserves rank, so this is positive
+    # definite exactly when the geometric `HᵀH` is (which `calc_pvt` has already
+    # checked via `calc_DOP`); the test is kept so a caller cannot reach an
+    # ill-conditioned inverse through this function alone. The bounded σ range of
+    # `pseudorange_variance` also bounds what weighting can cost the conditioning:
+    # `cond(√W·H) ≤ (σ_max/σ_min)·cond(H)`.
+    F = positive_definite_cholesky(Symmetric(H' * Diagonal(inv.(variances)) * H))
+    isnothing(F) && return nothing
+    C = inv(F)
+
+    R = ecef_to_enu_rotation(user_pos)
+    C_enu = R * SMatrix{3,3}(@view C[1:3, 1:3]) * R'
+
+    clock = 3 + primary_clock_index
+    FormalAccuracy(
+        sqrt(C_enu[1, 1] + C_enu[2, 2]) * m,    # horizontal (East² + North²)
+        sqrt(C_enu[3, 3]) * m,                  # vertical (Up)
+        sqrt(C[1, 1] + C[2, 2] + C[3, 3]) * m,  # 3D position (trace, frame invariant)
+        sqrt(C[clock, clock]) * m,              # reference system's clock, as a range
+    )
 end
 
 """
@@ -220,13 +276,34 @@ Calculates the user position by least squares method. The algorithm is based on 
 
 `bias_columns`: The per-satellite [`BiasColumns`](@ref) (clock and inter-frequency-bias columns).
 
+`weights`: Optional per-satellite least-squares weights, i.e. inverse a-priori
+measurement variances `1/σ²` (see [`pseudorange_variance`](@ref)) in the same order as
+`ρ`. `nothing` (the default) is ordinary least squares — every satellite equally
+precise. Weighting minimises `Σ wⱼ·(ρ̂ⱼ − ρⱼ)²` instead of `Σ (ρ̂ⱼ − ρⱼ)²`, so a noisy
+satellite still contributes its geometry but stops pulling the fix as hard as a
+precise one. Only the ratios of the weights matter; a common factor cancels.
+
 Returns `(ξ, residuals)`: the solved state vector
 `ξ = [x, y, z, tc₁, …, ifb₁, …]` and the per-satellite post-fit residual vector
-(modeled minus measured pseudorange, metres), in the same satellite order as `ρ`.
+(modeled minus measured pseudorange, metres), in the same satellite order as `ρ`. The
+residuals are raw metres in both cases — the weight-normalised residuals the solve
+works with internally are scaled back — so a caller comparing residuals across epochs
+compares the same quantity whether or not weights were supplied.
 """
-function user_position(sat_positions_mat, ρ, bias_columns::BiasColumns, prev_ξ = zeros(num_lsq_params(bias_columns)))
-    model! = (out, x, par) -> calc_ρ_hat!(out, x, par, bias_columns)
-    jacobian! = (J, x, par) -> calc_H!(J, x, par, bias_columns)
+function user_position(sat_positions_mat, ρ, bias_columns::BiasColumns,
+    prev_ξ = zeros(num_lsq_params(bias_columns)); weights = nothing)
+    # Weighting is applied by pre-whitening: scaling residual, Jacobian and directional
+    # second derivative of satellite j by √wⱼ turns the ordinary least-squares problem
+    # into the weighted one, since `‖√W(ρ̂−ρ)‖² = Σ wⱼ(ρ̂ⱼ−ρⱼ)²`. That is precisely what
+    # `LsqFit.curve_fit`'s own `wt` argument does internally, done here instead so the
+    # weight convention (inverse variance) is ours and identical across the LsqFit
+    # versions this package supports (0.16 deprecates a bare weight vector in favour of
+    # its own typed wrappers) — and so an unweighted epoch is left strictly unweighted
+    # rather than uniformly weighted, `scale === nothing` making every whitening a no-op.
+    scale = isnothing(weights) ? nothing : sqrt.(weights)
+    model! = (out, x, par) -> whiten!(calc_ρ_hat!(out, x, par, bias_columns), scale)
+    jacobian! = (J, x, par) -> whiten!(calc_H!(J, x, par, bias_columns), scale)
+    ρ_whitened = isnothing(scale) ? ρ : scale .* ρ
 
     # Two departures from LsqFit's Levenberg-Marquardt defaults, both about the scale of
     # this particular problem:
@@ -235,9 +312,10 @@ function user_position(sat_positions_mat, ρ, bias_columns::BiasColumns, prev_ξ
     #    below `x_tol·(x_tol + ‖ξ‖)` — and `‖ξ‖` here is dominated not by the position but
     #    by the clock bias, which carries the ~2e7 m of common range the pseudoranges are
     #    referred to. The 1e-8 default therefore calls it converged at a step of ~0.2 m,
-    #    so a solve that starts a metre from the optimum — an ordinary warm start from the
-    #    previous epoch — stops most of a metre short of it. 1e-13 puts the threshold at a
-    #    ~2 µm step, still ~1e3 × the rounding resolution of `ξ`.
+    #    so a solve that starts a metre from the optimum — an ordinary warm start, or the
+    #    weighted refinement solve `calc_pvt` makes about it — stops most of a metre short
+    #    of it. 1e-13 puts the threshold at a ~2 µm step, still ~1e3 × the rounding
+    #    resolution of `ξ`.
     #  - `lambda` is the initial (inverse) trust-region radius, and the default 10 damps
     #    the first steps to a fraction of the Gauss-Newton step — which is what makes the
     #    tolerance above bite so early. The pseudorange model is only mildly nonlinear, so
@@ -251,27 +329,34 @@ function user_position(sat_positions_mat, ρ, bias_columns::BiasColumns, prev_ξ
     # start from origin, ~6e6 m away) by trading per-iteration work for fewer iterations.
     # When prev_ξ is already near-converged, the extra Avv! evals are pure overhead.
     # Detect cold by checking the default zeros sentinel (origin position).
-    ξ_fit_ols = if iszero(prev_ξ)
+    ξ_fit = if iszero(prev_ξ)
         curve_fit(
-            model!, jacobian!, sat_positions_mat, ρ, collect(prev_ξ);
+            model!, jacobian!, sat_positions_mat, ρ_whitened, collect(prev_ξ);
             inplace = true,
-            avv! = (dir_deriv, par, v) -> calc_Avv!(dir_deriv, sat_positions_mat, par, v),
+            avv! = (dir_deriv, par, v) ->
+                whiten!(calc_Avv!(dir_deriv, sat_positions_mat, par, v), scale),
             lambda = 1e-8,
             min_step_quality = 0.0,
             x_tol = 1e-13,
         )
     else
         curve_fit(
-            model!, jacobian!, sat_positions_mat, ρ, collect(prev_ξ);
+            model!, jacobian!, sat_positions_mat, ρ_whitened, collect(prev_ξ);
             inplace = true,
             lambda = 1e-8,
             x_tol = 1e-13,
         )
     end
-    #    wt = 1 ./ (ξ_fit_ols.resid .^ 2)
-    #    ξ_fit_wls = curve_fit(ρ_hat, H, sat_positions_mat, ρ, wt, collect(prev_ξ))
-    return ξ_fit_ols.param, ξ_fit_ols.resid
+    residuals = isnothing(scale) ? ξ_fit.resid : ξ_fit.resid ./ scale
+    return ξ_fit.param, residuals
 end
+
+# Fold the per-satellite weight square roots into a residual vector, a Jacobian or a
+# directional-derivative vector — one row (satellite) per entry of `scale`, which
+# broadcasts along the first dimension for the matrix case. `nothing` is the
+# unweighted solve and returns the argument untouched.
+whiten!(out, ::Nothing) = out
+whiten!(out, scale) = (out .*= scale; out)
 
 """
 Computes user velocity
@@ -296,8 +381,14 @@ per-satellite Doppler-consistency / outlier indicator.
 
 Requires a geometry whose position design `H` has full column rank — the caller
 establishes that with [`calc_DOP`](@ref) before calling this; see the comment at the solve.
+
+`weights` are optional per-satellite inverse range-rate variances `1/σ²` (see
+[`range_rate_variance`](@ref)); `nothing` weights every satellite equally. The Doppler
+needs its own variances rather than the pseudorange ones because its noise comes from
+the carrier/frequency loop, not the code loop.
 """
-function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states, times, H)
+function calc_user_velocity_and_clock_drift(
+    sat_positions_and_velocities, states, times, H; weights = nothing)
     num_sats = length(states)
     # Normal-equations form of the 4-unknown velocity + clock-drift least squares.
     # The velocity design row is [eₓ e_y e_z 1]: the line-of-sight unit vector (H's
@@ -326,8 +417,14 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states
         a = SVector(e[1], e[2], e[3], 1.0)
         yⱼ = -(doppler * λ - clock_drift * SPEEDOFLIGHT - dot(e, get_sat_velocity(sat_pv)))
         rate_residuals[j] = yⱼ
-        HtH += a * a'
-        Hty += a * yⱼ
+        # Weighted normal equations: `wⱼ` scales this satellite's row of both `HᵀWH` and
+        # `HᵀWy`, the accumulated form of solving with the row scaled by √wⱼ. The residual
+        # stored above is the raw measurement either way, so the post-fit residuals below
+        # stay in m/s rather than becoming weight-normalised.
+        wⱼ = row_weight(weights, j)
+        HtH += wⱼ * a * a'
+        Hty += wⱼ * a * yⱼ
+
     end
     # `HtH` is positive definite whenever the position design `H` has full column rank,
     # which `calc_pvt` has established via `calc_DOP` before calling this: writing the
@@ -335,6 +432,9 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states
     # columns into the drift column and drops the IFB columns — `T` has orthogonal columns
     # of norms 1, 1, 1, √M, so `null(T) = {0}` and a full-rank `H` gives a full-rank `A`
     # (with `cond(A) ≤ √M·cond(H)`). Hence a plain Cholesky solve, no rank test of its own.
+    # Weighting does not weaken that argument: the weights are strictly positive and
+    # bounded (`range_rate_variance` clamps σ), so `AᵀWA` is positive definite exactly
+    # when `AᵀA` is, at a bounded cost in conditioning.
     #
     # This is why `calc_pvt` must keep the DOP check *ahead* of this call: with the order
     # reversed, a rank-deficient geometry reaches the solve below and throws
@@ -352,6 +452,12 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states
     end
     return velocity_and_drift, rate_residuals
 end
+
+# Weight of measurement row `j`, with `nothing` standing for the unweighted solve. The
+# unweighted case must stay exactly unweighted rather than uniformly weighted: a common
+# factor is mathematically irrelevant but not bit-identical through the solve.
+row_weight(::Nothing, j) = 1.0
+row_weight(weights, j) = weights[j]
 
 get_sat_position(x) = x.position
 get_sat_velocity(x) = x.velocity

--- a/src/user_position.jl
+++ b/src/user_position.jl
@@ -228,8 +228,27 @@ function user_position(sat_positions_mat, ρ, bias_columns::BiasColumns, prev_ξ
     model! = (out, x, par) -> calc_ρ_hat!(out, x, par, bias_columns)
     jacobian! = (J, x, par) -> calc_H!(J, x, par, bias_columns)
 
-    # Geodesic acceleration helps when starting far from the optimum (cold start
-    # from origin, ~6e6 m away) by trading per-iteration work for fewer iterations.
+    # Two departures from LsqFit's Levenberg-Marquardt defaults, both about the scale of
+    # this particular problem:
+    #
+    #  - `x_tol` is a *relative* step tolerance — the iteration stops once a step falls
+    #    below `x_tol·(x_tol + ‖ξ‖)` — and `‖ξ‖` here is dominated not by the position but
+    #    by the clock bias, which carries the ~2e7 m of common range the pseudoranges are
+    #    referred to. The 1e-8 default therefore calls it converged at a step of ~0.2 m,
+    #    so a solve that starts a metre from the optimum — an ordinary warm start from the
+    #    previous epoch — stops most of a metre short of it. 1e-13 puts the threshold at a
+    #    ~2 µm step, still ~1e3 × the rounding resolution of `ξ`.
+    #  - `lambda` is the initial (inverse) trust-region radius, and the default 10 damps
+    #    the first steps to a fraction of the Gauss-Newton step — which is what makes the
+    #    tolerance above bite so early. The pseudorange model is only mildly nonlinear, so
+    #    the full step is a good step here: 1e-8 leaves the iteration effectively
+    #    Gauss-Newton — measured at 2 to 5 iterations to nanometre level from 1 m, 100 km
+    #    or a cold start, against 8 to 16 with the default or with damping switched off
+    #    entirely — while keeping LM's machinery available, since a step that fails to
+    #    improve still grows `lambda` from there.
+    #
+    # Geodesic acceleration additionally helps when starting far from the optimum (cold
+    # start from origin, ~6e6 m away) by trading per-iteration work for fewer iterations.
     # When prev_ξ is already near-converged, the extra Avv! evals are pure overhead.
     # Detect cold by checking the default zeros sentinel (origin position).
     ξ_fit_ols = if iszero(prev_ξ)
@@ -237,13 +256,16 @@ function user_position(sat_positions_mat, ρ, bias_columns::BiasColumns, prev_ξ
             model!, jacobian!, sat_positions_mat, ρ, collect(prev_ξ);
             inplace = true,
             avv! = (dir_deriv, par, v) -> calc_Avv!(dir_deriv, sat_positions_mat, par, v),
-            lambda = 0.0,
+            lambda = 1e-8,
             min_step_quality = 0.0,
+            x_tol = 1e-13,
         )
     else
         curve_fit(
             model!, jacobian!, sat_positions_mat, ρ, collect(prev_ξ);
             inplace = true,
+            lambda = 1e-8,
+            x_tol = 1e-13,
         )
     end
     #    wt = 1 ./ (ξ_fit_ols.resid .^ 2)

--- a/test/pvt.jl
+++ b/test/pvt.jl
@@ -450,3 +450,35 @@ end
             [sinθ, 0.0, cosθ], [0.0, sinθ, cosθ], [-sinθ, 0.0, cosθ], [0.0, -sinθ, cosθ]])
     end
 end
+
+# Regression: the position solve must run to its optimum, not stop at the first step
+# LsqFit's *relative* `x_tol` calls small. `‖ξ‖` is dominated by the clock bias — the
+# ~2e7 m of common range the pseudoranges are referred to — which puts the default
+# tolerance at a ~0.2 m step, and with the default Levenberg-Marquardt damping a first
+# step is only a fraction of the distance to the optimum. A warm start a metre out
+# therefore took one ~10 cm step and reported convergence, returning a fix most of a
+# metre away from the one the very same measurements give from cold. See the solver
+# settings in `user_position`.
+@testset "a warm start converges to the same fix as a cold start" begin
+    kwargs = (; approximate_year = 2021, enable_ionospheric_correction = false,
+        enable_tropospheric_correction = false)
+    states = gps_l1_states(0.0Hz)
+    cold = calc_pvt(states; kwargs...)
+
+    # Previous solutions displaced by 1 m, 30 m and 100 km. With no position-dependent
+    # correction active the measurements define one optimum, so every start must reach
+    # it — to well under a millimetre, not to within the starting error.
+    for offset in ([1.0, -1.0, 1.0], [30.0, 0.0, -20.0], [1e5, 1e5, -1e5])
+        stale = PVTSolution(;
+            position = ECEF((Vector(cold.position) .+ offset)...),
+            time_correction = cold.time_correction,
+            reference_system = cold.reference_system,
+        )
+        warm = calc_pvt(states, stale; kwargs...)
+        @test norm(warm.position - cold.position) < 1e-4
+        @test warm.time ≈ cold.time
+        # The residuals are those of the converged fit, not of the stale position.
+        @test maximum(abs, [info.residual for info in values(warm.sats)]) ≈
+              maximum(abs, [info.residual for info in values(cold.sats)]) rtol = 1e-6
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 
 using Test, PositionVelocityTime, GNSSDecoder, AstroTime, GNSSSignals, Geodesy, Dates, LinearAlgebra
-using Unitful: Hz, m, s, °, ustrip
+using Unitful: Hz, m, s, °, dBHz, ustrip
 
 include("aqua.jl")
 include("fixtures.jl")
@@ -8,6 +8,7 @@ include("sat_time.jl")
 include("sat_position.jl")
 include("pvt.jl")
 include("dop.jl")
+include("weighted_least_squares.jl")
 include("cnav.jl")
 include("gps_l2c.jl")
 include("galileo_e5a.jl")

--- a/test/tracking_ext.jl
+++ b/test/tracking_ext.jl
@@ -1,5 +1,6 @@
 using Tracking
-using Tracking: TrackedSat, get_code_phase, get_carrier_doppler, get_carrier_phase
+using Tracking:
+    TrackedSat, get_code_phase, get_carrier_doppler, get_carrier_phase, estimate_cn0
 
 @testset "Tracking extension: SatelliteState from a Tracking sat state" begin
     # The extension is only available once Tracking is loaded.
@@ -19,4 +20,26 @@ using Tracking: TrackedSat, get_code_phase, get_carrier_doppler, get_carrier_pha
     @test state.code_phase == get_code_phase(sat_state)
     @test state.carrier_doppler == get_carrier_doppler(sat_state)
     @test state.carrier_phase == get_carrier_phase(sat_state)
+
+    # C/N₀ comes along automatically, so a tracking receiver gets the weighted solve
+    # without wiring anything up. This satellite's estimator has seen no prompt yet, so
+    # Tracking reports `0.0dBHz` — which the variance model reads as "not reported"
+    # rather than as an unusably weak signal, leaving this epoch unweighted.
+    @test state.cn0 == estimate_cn0(sat_state, typeof(gpsl1))
+    @test state.cn0 == 0.0dBHz
+    @test !PositionVelocityTime.has_measurement_uncertainty(state)
+    @test isnothing(state.pseudorange_variance)
+
+    # Both are overridable for a caller that owns its own error model.
+    overridden = SatelliteState(
+        decoder,
+        gpsl1,
+        sat_state;
+        cn0 = 42.0dBHz,
+        pseudorange_variance = (3.0m)^2,
+    )
+    @test overridden.cn0 == 42.0dBHz
+    @test overridden.pseudorange_variance == (3.0m)^2
+    @test PositionVelocityTime.has_measurement_uncertainty(overridden)
+    @test isnothing(SatelliteState(decoder, gpsl1, sat_state; cn0 = nothing).cn0)
 end

--- a/test/weighted_least_squares.jl
+++ b/test/weighted_least_squares.jl
@@ -1,0 +1,389 @@
+# Weighting the least-squares solve by measurement uncertainty (C/N₀ + elevation)
+# instead of treating every satellite as equally precise. Two things are pinned here:
+# the variance model itself, and that the weights actually buy accuracy — a fix whose
+# satellites carry the noise their C/N₀ implies is measurably better when weighted.
+
+using Random: MersenneTwister
+
+const C_LIGHT = PositionVelocityTime.SPEEDOFLIGHT
+
+# A satellite's code-chip length in metres: one chip of code phase is one chip length
+# of pseudorange (the pseudorange is `(t_ref − t_transmit)·c` and the code phase
+# advances the transmit time, so *more* code phase is *less* range).
+chip_length(system) = C_LIGHT / ustrip(Hz, get_code_frequency(system))
+
+"Copy of `state` with the given fields replaced."
+function with_state(
+    state;
+    code_phase = state.code_phase,
+    carrier_doppler = state.carrier_doppler,
+    cn0 = state.cn0,
+    pseudorange_variance = state.pseudorange_variance,
+)
+    SatelliteState(;
+        decoder = state.decoder,
+        system = state.system,
+        code_phase,
+        carrier_doppler,
+        carrier_phase = state.carrier_phase,
+        cn0,
+        pseudorange_variance,
+    )
+end
+
+"Copy of `state` whose pseudorange carries an additional error of `error_metres`."
+function with_range_error(state, error_metres)
+    chips = error_metres / chip_length(state.system)
+    with_state(state; code_phase = state.code_phase - chips)
+end
+
+"The same states with their C/N₀ removed, i.e. the epoch as unweighted least squares."
+strip_cn0(states) = [with_state(s; cn0 = nothing) for s in states]
+
+rms(x) = sqrt(sum(abs2, x) / length(x))
+
+"Copy of `state` whose range rate carries an additional error of `error_m_per_s`."
+function with_range_rate_error(state, error_m_per_s)
+    λ = C_LIGHT / ustrip(Hz, get_center_frequency(state.system))
+    with_state(state; carrier_doppler = state.carrier_doppler - error_m_per_s / λ * Hz)
+end
+
+@testset "pseudorange variance model" begin
+    pseudorange_variance = PositionVelocityTime.pseudorange_variance
+    gpsl1 = GPSL1CA()
+    zenith = deg2rad(90)
+
+    # Noise falls with C/N₀ — the whole point of weighting. The C/N₀ term is the
+    # coherent-DLL thermal jitter `(c/f_chip)·√(B_n·d/2)·10^(−CN0/20)`, ≈ 1.2 m at
+    # 45 dBHz for GPS L1 C/A, so a 30 dBHz satellite is several times noisier.
+    σ(cn0, el = zenith, system = gpsl1) = sqrt(pseudorange_variance(system, cn0, el))
+    @test σ(30.0dBHz) > σ(35.0dBHz) > σ(45.0dBHz) > σ(55.0dBHz)
+    thermal(cn0) = sqrt(σ(cn0)^2 - σ(nothing)^2)
+    @test thermal(45.0dBHz) ≈ chip_length(gpsl1) * sqrt(0.5) * 10^(-45 / 20) rtol = 1e-12
+    # 15 dB of C/N₀ is a factor 10^(15/20) ≈ 5.6 in the thermal term.
+    @test thermal(30.0dBHz) / thermal(45.0dBHz) ≈ 10^(15 / 20)
+
+    # A wider-band signal has a shorter chip and thus a sharper correlation peak: the
+    # same C/N₀ on GPS L5 (10.23 Mcps) is ten times less code noise than on L1 C/A.
+    thermal_l5 = sqrt(pseudorange_variance(GPSL5I(), 45.0dBHz, zenith) -
+                      pseudorange_variance(GPSL5I(), nothing, zenith))
+    @test thermal(45.0dBHz) / thermal_l5 ≈ 10 rtol = 1e-6
+
+    # Elevation mapping: noise grows towards the horizon, saturates below the
+    # tropospheric model's low-elevation bound rather than diverging (including for a
+    # satellite that the current position estimate puts below the horizon).
+    @test σ(45.0dBHz, deg2rad(90)) < σ(45.0dBHz, deg2rad(30)) < σ(45.0dBHz, deg2rad(5))
+    @test σ(45.0dBHz, deg2rad(1)) == σ(45.0dBHz, deg2rad(-30)) ==
+          σ(45.0dBHz, PositionVelocityTime._LOW_ELEVATION_THRESHOLD)
+
+    # Unknown inputs drop their term instead of guessing: no elevation (cold start, no
+    # position yet) and no C/N₀ (a caller that does not report it) are both fine, and
+    # leave the floor that keeps a strong satellite from taking over the fix.
+    @test pseudorange_variance(gpsl1, nothing, nothing) ==
+          PositionVelocityTime._RESIDUAL_UERE_SIGMA^2
+    @test σ(nothing, deg2rad(30)) < σ(30.0dBHz, deg2rad(30))
+    @test σ(45.0dBHz, nothing) < σ(45.0dBHz, deg2rad(30))
+
+    # Robustness ceiling: a satellite whose C/N₀ reads absurdly low is heavily
+    # de-weighted but never silently dropped, and the floor keeps every σ meaningful.
+    # `0.0dBHz` — what Tracking's estimator reports before it has integrated a prompt —
+    # counts as "not reported", not as an unusable signal.
+    lo, hi = PositionVelocityTime._PSEUDORANGE_SIGMA_BOUNDS
+    @test σ(5.0dBHz) == hi
+    @test lo < σ(90.0dBHz, deg2rad(90)) < σ(-10.0dBHz, deg2rad(0)) ≤ hi
+    @test σ(0.0dBHz) == σ(nothing)
+    @test σ(-5.0dBHz) == σ(nothing)
+    @test !PositionVelocityTime._is_usable_cn0(nothing)
+    @test !PositionVelocityTime._is_usable_cn0(0.0dBHz)
+    @test PositionVelocityTime._is_usable_cn0(20.0dBHz)
+
+    # C/N₀ enters as a linear ratio: 45 dBHz is 10^4.5 Hz.
+    @test PositionVelocityTime._linear_cn0(45.0dBHz) ≈ 10^4.5
+
+    # The per-satellite form takes the state's C/N₀, and an explicit variance replaces
+    # the model outright (elevation and C/N₀ then do not matter).
+    state = with_state(gps_l1_states(0.0Hz)[1]; cn0 = 30.0dBHz)
+    @test pseudorange_variance(state, zenith) ==
+          pseudorange_variance(gpsl1, 30.0dBHz, zenith)
+    override = with_state(state; pseudorange_variance = (7.0m)^2)
+    @test pseudorange_variance(override, zenith) == 49.0
+    @test pseudorange_variance(override, deg2rad(5)) == 49.0
+    # A supplied variance is bounded like a modeled one, so no caller can hand a
+    # satellite an infinite (or `NaN`) weight and let it dictate the fix.
+    bounded(variance) = pseudorange_variance(
+        with_state(state; pseudorange_variance = variance), zenith)
+    @test bounded(0.0m^2) == lo^2
+    @test bounded((1e6m)^2) == hi^2
+    @test bounded(NaN * m^2) == hi^2
+    @test PositionVelocityTime.has_measurement_uncertainty(override)
+    @test PositionVelocityTime.has_measurement_uncertainty(state)
+    unreported(cn0) = !PositionVelocityTime.has_measurement_uncertainty(
+        with_state(state; cn0))
+    @test unreported(nothing)
+    @test unreported(0.0dBHz)
+end
+
+@testset "range rate variance model" begin
+    range_rate_variance = PositionVelocityTime.range_rate_variance
+    gpsl1 = GPSL1CA()
+    σv(cn0, system = gpsl1) = sqrt(range_rate_variance(system, cn0))
+
+    # Doppler noise follows the carrier loop, so it has its own C/N₀ dependence — and
+    # its own floor, which is all that is left when no C/N₀ is reported.
+    @test σv(30.0dBHz) > σv(40.0dBHz) > σv(50.0dBHz) > σv(nothing)
+    @test σv(nothing) == PositionVelocityTime._RANGE_RATE_SIGMA_FLOOR
+    @test σv(0.0dBHz) == σv(nothing)
+    thermal(cn0, system = gpsl1) = sqrt(σv(cn0, system)^2 - σv(nothing)^2)
+    @test thermal(30.0dBHz) / thermal(45.0dBHz) ≈ 10^(15 / 20)
+    # A metre-per-second scale, not a metre one: the FLL sees the carrier, not the code.
+    @test 0.05 < σv(30.0dBHz) < 0.2
+    # The clamp is a guard, so every reading stays inside it.
+    lo, hi = PositionVelocityTime._RANGE_RATE_SIGMA_BOUNDS
+    @test all(cn0 -> lo ≤ σv(cn0) ≤ hi, (0.1dBHz, 5.0dBHz, 45.0dBHz, 90.0dBHz))
+    # Longer wavelength, more metres per Hz of Doppler error: L5 (1176 MHz) over
+    # L1 (1575 MHz).
+    @test thermal(45.0dBHz, GPSL5I()) > thermal(45.0dBHz)
+    @test range_rate_variance(with_state(gps_l1_states(0.0Hz)[1]; cn0 = 30.0dBHz)) ==
+          range_rate_variance(gpsl1, 30.0dBHz)
+end
+
+@testset "an epoch without reported uncertainty is solved exactly as before" begin
+    kwargs = (; approximate_year = 2021, enable_ionospheric_correction = false,
+        enable_tropospheric_correction = false)
+    states = gps_l1_states(0.0Hz)
+    pvt = calc_pvt(states; kwargs...)
+
+    # No satellite reports a C/N₀ or a variance, so nothing is weighted: every
+    # satellite is credited the same nominal UERE …
+    nominal = PositionVelocityTime._NOMINAL_PSEUDORANGE_SIGMA * m
+    @test all(info -> info.pseudorange_sigma == nominal, values(pvt.sats))
+    # … and the formal accuracy is then exactly the familiar DOP × UERE product, which
+    # is what makes it comparable to the geometric DOP it is reported alongside.
+    @test pvt.accuracy.horizontal ≈ pvt.dop.HDOP * nominal
+    @test pvt.accuracy.vertical ≈ pvt.dop.VDOP * nominal
+    @test pvt.accuracy.position ≈ pvt.dop.PDOP * nominal
+    @test pvt.accuracy.time ≈ pvt.dop.TDOP * nominal
+
+    # Reporting a C/N₀ leaves the DOP untouched — it is a geometric quantity and must
+    # not silently become a weighted one — while the accuracy does change. (The DOPs are
+    # equal to a few parts in 1e8, not bit-identical: they are read off the design matrix
+    # at each solve's own converged position, and those sit a few centimetres apart.)
+    weighted = calc_pvt([with_state(s; cn0 = 45.0dBHz) for s in states]; kwargs...)
+    @test weighted.dop.GDOP ≈ pvt.dop.GDOP rtol = 1e-6
+    @test weighted.dop.HDOP ≈ pvt.dop.HDOP rtol = 1e-6
+    @test weighted.dop.PDOP ≈ pvt.dop.PDOP rtol = 1e-6
+    @test weighted.accuracy.position < pvt.accuracy.position
+    @test all(info -> info.pseudorange_sigma < nominal, values(weighted.sats))
+end
+
+@testset "formal accuracy" begin
+    calc_formal_accuracy = PositionVelocityTime.calc_formal_accuracy
+    user = ECEF(ECEFfromLLA(wgs84)(LLA(50.1, 8.7, 120.0)))
+    function ecef_los(az, el)
+        enu = ENU(cos(el) * sin(az), cos(el) * cos(az), sin(el))
+        Vector(ECEFfromENU(user, wgs84)(enu)) .- Vector(user)
+    end
+    azels = [(0.0, deg2rad(80)), (deg2rad(90), deg2rad(30)), (deg2rad(180), deg2rad(45)),
+        (deg2rad(270), deg2rad(20)), (deg2rad(45), deg2rad(60))]
+    H = reduce(vcat, [[ecef_los(az, el)' 1.0] for (az, el) in azels])
+
+    # Uniform variances reproduce DOP × σ, the classic accuracy estimate.
+    dop = PositionVelocityTime.calc_DOP(H, user)
+    accuracy = calc_formal_accuracy(H, fill(4.0, 5), user)
+    @test accuracy.horizontal ≈ dop.HDOP * 2.0m
+    @test accuracy.vertical ≈ dop.VDOP * 2.0m
+    @test accuracy.position ≈ dop.PDOP * 2.0m
+    @test accuracy.time ≈ dop.TDOP * 2.0m
+    # Horizontal/vertical split of the same 3D quantity, taken in the ENU tangent plane.
+    @test accuracy.position ≈ hypot(accuracy.horizontal, accuracy.vertical)
+
+    # It is a covariance, so it scales with the assumed measurement σ …
+    @test calc_formal_accuracy(H, fill(16.0, 5), user).position ≈ 2 * accuracy.position
+    # … and a satellite trusted less can only make the fix less certain.
+    degraded = calc_formal_accuracy(H, [100.0, 4.0, 4.0, 4.0, 4.0], user)
+    @test degraded.position > accuracy.position
+    # A rank-deficient geometry is reported, not thrown — as in `calc_DOP`.
+    @test isnothing(calc_formal_accuracy(repeat([1.0 0.0 0.0 1.0], 4), fill(4.0, 4), user))
+end
+
+@testset "a satellite trusted less pulls the fix less" begin
+    kwargs = (; approximate_year = 2021, enable_ionospheric_correction = false,
+        enable_tropospheric_correction = false)
+    states = gps_l1_states(0.0Hz)
+
+    # Five satellites, one of which is handed a 60 m pseudorange error. Weighted with an
+    # (over-)confident σ on the four good ones and the model ceiling on the broken one,
+    # the fix should end up close to what the four good satellites alone give — the
+    # broken satellite contributes its geometry, not its error.
+    good = [with_state(s; pseudorange_variance = (0.5m)^2) for s in states[1:4]]
+    broken = with_state(with_range_error(states[5], 60.0); pseudorange_variance = (50.0m)^2)
+    without_broken = calc_pvt(states[1:4]; kwargs...)
+    unweighted = calc_pvt([states[1:4]; [with_range_error(states[5], 60.0)]]; kwargs...)
+    weighted = calc_pvt([good; [broken]]; kwargs...)
+    @test norm(weighted.position - without_broken.position) <
+          0.05 * norm(unweighted.position - without_broken.position)
+
+    # The residual reported per satellite stays the raw metre residual, weighted or not,
+    # so it remains comparable across epochs; the σ it was weighted by is reported
+    # alongside it, which is what turns it into a normalised residual for fault
+    # detection. The broken satellite is the one that stands out.
+    broken_info = weighted.sats[(:GPSL1CA, broken.decoder.prn)]
+    @test broken_info.pseudorange_sigma == 50.0m
+    @test abs(broken_info.residual) > 40m
+    @test all(
+        info -> abs(info.residual) < 5m,
+        [weighted.sats[(:GPSL1CA, s.decoder.prn)] for s in good],
+    )
+end
+
+@testset "the weighted velocity solve keeps reporting raw range-rate residuals" begin
+    kwargs = (; approximate_year = 2021, enable_ionospheric_correction = false,
+        enable_tropospheric_correction = false)
+    # A weak satellite whose Doppler is off by 1 m/s. Its C/N₀ earns it a small weight, so
+    # it barely moves the velocity — but the residual reported for it is the raw m/s
+    # disagreement, not a weight-normalised one, so it still stands out as the outlier.
+    states = gps_l1_states(0.0Hz)[1:6]
+    reported = [with_state(s; cn0 = i == 1 ? 30.0dBHz : 48.0dBHz)
+                for (i, s) in enumerate(states)]
+    clean = calc_pvt(reported; kwargs...)
+    broken_prn = reported[1].decoder.prn
+    noisy = [i == 1 ? with_range_rate_error(s, 1.0) : s for (i, s) in enumerate(reported)]
+    weighted = calc_pvt(noisy; kwargs...)
+
+    rate_residual(pvt, prn) = pvt.sats[(:GPSL1CA, prn)].rate_residual
+    @test all(info -> isfinite(ustrip(info.rate_residual)), values(weighted.sats))
+    # The 1 m/s error shows up as ~1 m/s of residual on that satellite …
+    @test abs(rate_residual(weighted, broken_prn) - rate_residual(clean, broken_prn)) >
+          0.8m / s
+    # … and the velocity barely moves, because that satellite is the one trusted least.
+    unweighted = calc_pvt(strip_cn0(noisy); kwargs...)
+    @test norm(weighted.velocity - clean.velocity) <
+          0.5 * norm(unweighted.velocity - calc_pvt(strip_cn0(reported); kwargs...).velocity)
+end
+
+# The point of the exercise: satellites whose C/N₀ says they are noisy, carrying exactly
+# that noise, degrade the fix less when the solve knows about it. Everything below is
+# driven by one seeded RNG, so it is a fixed computation rather than a flaky one.
+#
+# Three marginal satellites among nine — the case the issue describes: a receiver admits
+# a weak-but-tracked satellite (four are needed for a fix at all) and then has to live
+# with its noise. Each estimator's error is measured against its *own* noiseless fix,
+# because that isolates what is being compared: how much of the injected measurement
+# noise reaches the solution. (The fixture measurements carry real-world errors of their
+# own, so the two noiseless fixes are not identical — they differ by ~0.9 m — and neither
+# is a ground truth.)
+const WEAK_CN0 = 30.0dBHz
+const STRONG_CN0 = 48.0dBHz
+graded_cn0_states() = [
+    with_state(s; cn0 = i ≤ 3 ? WEAK_CN0 : STRONG_CN0)
+    for (i, s) in enumerate(gps_l1_states(0.0Hz))
+]
+
+@testset "a degraded-C/N₀ subset degrades a weighted fix less" begin
+    kwargs = (; approximate_year = 2021, enable_ionospheric_correction = false,
+        enable_tropospheric_correction = false)
+    reported = graded_cn0_states()
+
+    # Noiseless reference fixes, and the σ the model assigns each satellite (elevation
+    # included). The noise below is drawn with exactly the σ the solve is told to
+    # expect, so what is measured is the weighting, not a model mismatch.
+    truth = calc_pvt(reported; kwargs...)
+    ols_truth = calc_pvt(strip_cn0(reported); kwargs...)
+    σ = [ustrip(m, truth.sats[(:GPSL1CA, s.decoder.prn)].pseudorange_sigma)
+         for s in reported]
+    # The marginal satellites really are the noisy ones — every one of them noisier than
+    # every strong one, ~7 m against ~2 m (the 30 dBHz / 48 dBHz code-noise gap).
+    @test minimum(σ[1:3]) > maximum(σ[4:end])
+
+    # One realisation, spelled out: +2σ on the three weak satellites and −2σ on the
+    # strong ones, a jolt no estimator can average away — the weighted fix stays closer.
+    errors = [i ≤ 3 ? 2σ[i] : -2σ[i] for i in eachindex(σ)]
+    noisy = [with_range_error(s, e) for (s, e) in zip(reported, errors)]
+    @test norm(calc_pvt(noisy; kwargs...).position - truth.position) <
+          norm(calc_pvt(strip_cn0(noisy); kwargs...).position - ols_truth.position)
+
+    # And as an RMS error over 150 realisations — the claim that matters, since a single
+    # draw can favour either estimator. Weighted least squares is the minimum-variance
+    # estimator when the weights are the true inverse variances (Gauss-Markov), so it
+    # must win on average; here it does by ~21 % of the RMS error (6.5 m against 8.2 m),
+    # and the velocity below by ~60 %.
+    rng = MersenneTwister(20260805)
+    ols_errors = Float64[]
+    wls_errors = Float64[]
+    for _ in 1:150
+        draw = [with_range_error(s, σⱼ * randn(rng)) for (s, σⱼ) in zip(reported, σ)]
+        push!(ols_errors,
+            norm(calc_pvt(strip_cn0(draw); kwargs...).position - ols_truth.position))
+        push!(wls_errors, norm(calc_pvt(draw; kwargs...).position - truth.position))
+    end
+    @test rms(wls_errors) < 0.85 * rms(ols_errors)
+    # Not just an average: the weighted fix is the closer of the two in most individual
+    # realisations as well. (A per-realisation *guarantee* is not on offer — a single
+    # noise draw can favour either estimator, which is why the RMS above is the claim.)
+    @test count(wls_errors .< ols_errors) > 0.6 * length(wls_errors)
+
+    # The reported formal accuracy is a usable prediction of that spread, not merely an
+    # ordering: the empirical 3D RMS error lands within 50 % of it.
+    predicted = ustrip(m, truth.accuracy.position)
+    @test 0.5 * predicted < rms(wls_errors) < 1.5 * predicted
+    # The unweighted solve's own spread is *not* predicted by its accuracy figure, which
+    # assumes a uniform nominal UERE — one more reason to report the weighted one.
+    @test rms(ols_errors) > ustrip(m, ols_truth.accuracy.position) * 0.5
+end
+
+@testset "a degraded-C/N₀ subset degrades a weighted velocity less" begin
+    kwargs = (; approximate_year = 2021, enable_ionospheric_correction = false,
+        enable_tropospheric_correction = false)
+    reported = graded_cn0_states()
+    truth = calc_pvt(reported; kwargs...)
+    ols_truth = calc_pvt(strip_cn0(reported); kwargs...)
+    # Doppler noise comes from the carrier loop, so the velocity solve is weighted by
+    # `range_rate_variance` — its own model — rather than by the pseudorange σ.
+    σv = [sqrt(PositionVelocityTime.range_rate_variance(s)) for s in reported]
+    @test minimum(σv[1:3]) > maximum(σv[4:end])
+
+    rng = MersenneTwister(20260806)
+    ols_errors = Float64[]
+    wls_errors = Float64[]
+    for _ in 1:150
+        draw = [with_range_rate_error(s, σⱼ * randn(rng)) for (s, σⱼ) in zip(reported, σv)]
+        push!(ols_errors,
+            norm(calc_pvt(strip_cn0(draw); kwargs...).velocity - ols_truth.velocity))
+        push!(wls_errors, norm(calc_pvt(draw; kwargs...).velocity - truth.velocity))
+    end
+    @test rms(wls_errors) < 0.6 * rms(ols_errors)
+    @test count(wls_errors .< ols_errors) > 0.75 * length(wls_errors)
+end
+
+# The weighted solve is only worth anything if it actually converges to the weighted
+# optimum. It does from anywhere — but only because of the solver settings in
+# `user_position`: with LsqFit's defaults the iteration stops at the first step shorter
+# than `x_tol·‖ξ‖`, and `‖ξ‖` is dominated by the ~2e7 m clock bias, so a heavily damped
+# first step would end the solve up to a metre short on an ordinary warm start.
+@testset "the solve converges to the same fix from any starting point" begin
+    kwargs = (; approximate_year = 2021, enable_ionospheric_correction = false,
+        enable_tropospheric_correction = false)
+    reported = [with_state(s; cn0 = 40.0dBHz) for s in gps_l1_states(0.0Hz)]
+    cold = calc_pvt(reported; kwargs...)
+
+    # Warm-starting from the answer, and from previous fixes displaced by 1 m or 100 m,
+    # all land on the same solution to well under a millimetre. A 100 km-stale start is
+    # allowed a few centimetres: the a-priori weights are evaluated about the *reference*
+    # position (as the atmospheric delays are), and 100 km moves the elevations enough to
+    # move the σ they map to — so that is a slightly differently weighted epoch, not an
+    # unconverged solve.
+    for (offset, tolerance) in (
+        [0.0, 0.0, 0.0] => 1e-4,
+        [1.0, -1.0, 1.0] => 1e-4,
+        [100.0, 0.0, -60.0] => 1e-4,
+        [1e5, 1e5, -1e5] => 0.05,
+    )
+        stale = PVTSolution(;
+            position = ECEF((Vector(cold.position) .+ offset)...),
+            time_correction = cold.time_correction,
+            reference_system = cold.reference_system,
+        )
+        warm = calc_pvt(reported, stale; kwargs...)
+        @test norm(warm.position - cold.position) < tolerance
+    end
+end


### PR DESCRIPTION
Closes #65. **Stacked on #68** (`converge-the-position-solve`) — that fix is a prerequisite, not a convenience: the weighted refinement solve always starts a little away from the weighted optimum, so without it every weighted epoch stopped ~0.7 m short and the accuracy gain vanished. Review #68 first; this PR's base will retarget to `master` once it lands.

## What changes

`SatelliteState` gains two optional fields, both defaulting to `nothing`:

- `cn0` — a `dBHz` level, matching `Tracking.estimate_cn0`
- `pseudorange_variance` — e.g. `(3.0m)^2`, for a caller that owns its own error model

As soon as **any** satellite of an epoch carries either, the position solve minimises `Σ (ρ̂ⱼ − ρⱼ)²/σ²ⱼ` and the velocity solve weights its normal equations by the Doppler's own variance. With neither, the epoch is the ordinary least squares it was — unweighted behaviour is unchanged, which is what keeps this non-breaking for existing callers.

The Tracking extension forwards `estimate_cn0` of the ranging signal automatically, so a tracking receiver (GNSSReceiver.jl#118's marginal-C/N₀ backstop, which motivated the issue) gets the weighted solve without wiring anything up. `cn0`/`pseudorange_variance` are overridable there, and the `0.0dBHz` a fresh estimator reports counts as "not reported" rather than as an unusably weak signal.

## The variance models (`src/measurement_variance.jl`)

The standard combined form the issue proposes, `σ² = σ²_UERE + (a/sin El)² + b²·10^(−CN0/10)`:

| term | value | what it stands for |
|---|---|---|
| UERE floor | 1.5 m | residual ephemeris/clock; bounds a strong satellite's leverage |
| elevation, `a/sin El` | 0.5 m at zenith → 5.7 m at 5° | multipath + the residual of the *broadcast* atmospheric models, which is itself ~1/sin(El)-mapped. Not redundant with C/N₀: it covers errors C/N₀ cannot see, and multipath can even *raise* C/N₀ (SIGMA-Δ, Brunner et al. 1999) |
| thermal, C/N₀ | 1.2 m at 45 dBHz, 6.5 m at 30 dBHz (L1 C/A) | coherent-DLL jitter `(c/f_chip)·√(B_n·d/2)·10^(−CN0/20)`; the coefficient is **derived per signal from its chipping rate**, so GPS L5 is credited its 10× sharper correlation peak automatically rather than needing a tuned constant |

σ is clamped to [0.5, 50] m — a supplied variance too, so a zero/`NaN`/absurd value cannot produce an infinite weight. That also bounds the conditioning cost of weighting (`cond(√W·H) ≤ (σ_max/σ_min)·cond(H)`). The Doppler gets its own FLL-derived variance, since its noise follows the carrier loop, not the DLL; below ~2.87° elevation the σ saturates at the same bound the tropospheric mapping uses.

Elevation comes from the reference position the epoch is solved about, exactly as the atmospheric delays do — a metre-accurate position is plenty, so no iterate-to-convergence.

## Design decisions from the issue

- **DOP stays geometric.** `pvt.dop` remains `(HᵀH)⁻¹` and is unaffected by weighting, so it keeps meaning what every receiver and textbook means by it. The weighted covariance is a *separate* new field, `pvt.accuracy::FormalAccuracy` — 1σ horizontal, vertical, 3D and clock accuracy **in metres**. With no uncertainty reported it reduces exactly to the familiar DOP × nominal-UERE product (tested).
- **Residuals stay raw.** `SatInfo.residual` is still metres, weighted or not, so it is comparable across epochs; the new `SatInfo.pseudorange_sigma` reports the σ it was weighted by, and their ratio is the normalised residual RAIM (#9) wants. v5.0.0's `rate_residual` likewise stays raw m/s under weighting.
- **Conditioning / rank.** Weights are strictly positive and bounded, so `HᵀWH` is positive definite exactly when `HᵀH` is — the DOP-check-before-velocity-solve invariant survives, and the argument is documented where it is relied on.
- **Weighting mechanism.** Pre-whitening (√w on residual, Jacobian and the geodesic-acceleration term) rather than `LsqFit`'s `wt`, which deprecates a bare inverse-variance vector in 0.16 and would tie the weight convention to the LsqFit version across the 0.12–0.16 compat range.

## Does it actually help?

GPS L1 fixtures, three of nine satellites at 30 dBHz and six at 48 dBHz, each perturbed by the noise its own σ implies, 150 seeded realisations, each estimator measured against its own noiseless fix:

| | unweighted | weighted |
|---|---|---|
| 3D position RMS error | 8.2 m | **6.5 m** (−21 %) |
| velocity RMS error | 0.099 m/s | **0.043 m/s** (−57 %) |
| closer in individual realisations | — | 67 % of draws |

and the reported `accuracy.position` (6.2 m) predicts the weighted spread to within 5 %. Also tested: a satellite handed a 60 m error and the σ ceiling leaves the fix within 5 % of the four-good-satellite fix; a deterministic ±2σ realisation; the model's monotonicity, clamping and unknown-input handling; the extension's C/N₀ forwarding.

`test/weighted_least_squares.jl` is new (~390 lines, 74 assertions); `Random` joins the test target for the seeded draws. Full suite and `docs/make.jl` pass.

## Deliberately left out

Normalised residuals as a *reported* field and the RAIM hook (#9) — `pseudorange_sigma` is the input they need, so that can land separately. The opt-in real-data integration test (`PVT_RUN_INTEGRATION_TEST=true`) was not run here; it now exercises weighting on real C/N₀s through the extension and is worth a run before merge.

## Breaking

`PVTSolution` gains `accuracy` and `SatInfo` gains `pseudorange_sigma`, so positional construction of either changes arity (reading is additive). Same shape of break as v5.0.0's `rate_residual`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)