### PR TITLE
fix: report residuals as observed minus computed

### DIFF
--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -160,13 +160,20 @@ satellite used in the fix).
 - `position::ECEF`: Satellite ECEF position at transmit time (metres).
 - `time::Float64`: Satellite transmit time (system time of week, seconds).
 - `residual::typeof(1.0m)`: Post-fit least-squares pseudorange residual (metres) — the
-  modeled minus the (atmosphere-corrected) measured pseudorange. A per-satellite
+  (atmosphere-corrected) measured minus the modeled pseudorange. A per-satellite
   fit-quality / outlier indicator.
 - `rate_residual::typeof(1.0m/s)`: Post-fit least-squares range-rate residual (metres per
-  second) — the modeled minus the measured range rate of the carrier-Doppler velocity and
+  second) — the measured minus the modeled range rate of the carrier-Doppler velocity and
   clock-drift solve. The rate-domain counterpart of `residual`: it flags a satellite whose
   Doppler disagrees with the velocity fix (cycle slips, dynamics) independently of its
   pseudorange.
+
+Both are *measured minus modeled* ("observed minus computed"), the orientation GNSS
+software reports observation residuals in — RTKLIB's `rescode` / `resdop`, and GNSS-SDR
+and PocketSDR through it. Note that `rate_residual` follows `resdop` in the geometric
+range-rate sense, positive while the satellite recedes; a receiver forming the same
+residual from its tracking loops' `λ · carrier_doppler` works in the opposite sign (see
+`calc_user_velocity_and_clock_drift`, whose `yⱼ` sets that sign).
 """
 struct SatInfo
     position::ECEF

--- a/src/user_position.jl
+++ b/src/user_position.jl
@@ -222,7 +222,13 @@ Calculates the user position by least squares method. The algorithm is based on 
 
 Returns `(ξ, residuals)`: the solved state vector
 `ξ = [x, y, z, tc₁, …, ifb₁, …]` and the per-satellite post-fit residual vector
-(modeled minus measured pseudorange, metres), in the same satellite order as `ρ`.
+(measured minus modeled pseudorange, metres), in the same satellite order as `ρ`.
+
+`LsqFit` reports its own residual as `model - data`, so the returned vector negates it.
+Measured − modeled ("observed minus computed") is how GNSS software reports observation
+residuals — RTKLIB's `rescode`, and GNSS-SDR and PocketSDR through it — and the negation
+is the whole of the difference: it is applied to the converged fit, so the solve itself
+is untouched.
 """
 function user_position(sat_positions_mat, ρ, bias_columns::BiasColumns, prev_ξ = zeros(num_lsq_params(bias_columns)))
     model! = (out, x, par) -> calc_ρ_hat!(out, x, par, bias_columns)
@@ -270,7 +276,10 @@ function user_position(sat_positions_mat, ρ, bias_columns::BiasColumns, prev_ξ
     end
     #    wt = 1 ./ (ξ_fit_ols.resid .^ 2)
     #    ξ_fit_wls = curve_fit(ρ_hat, H, sat_positions_mat, ρ, wt, collect(prev_ξ))
-    return ξ_fit_ols.param, ξ_fit_ols.resid
+    # `-` and not an in-place negation: `resid` aliases the differentiable's own
+    # function-value cache inside `LsqFit`, so mutating it reaches into the library's
+    # internals for the sake of one small vector per epoch.
+    return ξ_fit_ols.param, -ξ_fit_ols.resid
 end
 
 """
@@ -289,10 +298,13 @@ drift of the inter-system time offset (e.g. the GGTO rate `A_1G`), which is
 every satellite constrain the four unknowns instead of spending a column per
 system.
 
-The residuals are `modeled − measured` range rate (m/s), the same orientation as the
+The residuals are `measured − modeled` range rate (m/s), the same orientation as the
 pseudorange residuals of [`user_position`](@ref) and in the same satellite order as
 `states`. They are the range-rate analogue of the post-fit pseudorange residual: a
-per-satellite Doppler-consistency / outlier indicator.
+per-satellite Doppler-consistency / outlier indicator. Measured and modeled are both
+taken in `yⱼ`'s sense below, in which a *receding* satellite reads positive — the same
+quantity and sign as RTKLIB's `resdop` residual, and hence the negative of the
+Doppler-signed range rate a tracking loop works in (see the note at the residual loop).
 
 Requires a geometry whose position design `H` has full column rank — the caller
 establishes that with [`calc_DOP`](@ref) before calling this; see the comment at the solve.
@@ -341,14 +353,21 @@ function calc_user_velocity_and_clock_drift(sat_positions_and_velocities, states
     # `SingularException` — the failure this arrangement exists to prevent.
     velocity_and_drift = cholesky(Symmetric(HtH)) \ Hty
 
-    # Post-fit residual, modeled minus measured: the design row `[e 1]` (rebuilt from
-    # H's line-of-sight columns, as above) applied to the solved state, minus the
-    # measurement stored in the accumulation loop.
+    # Post-fit residual, measured minus modeled: the measurement stored in the
+    # accumulation loop, minus the design row `[e 1]` (rebuilt from H's line-of-sight
+    # columns, as above) applied to the solved state.
+    #
+    # `yⱼ` carries `-doppler * λ`, so it — and this residual with it — runs in the
+    # geometric range-rate sense (positive while the satellite recedes), not the
+    # Doppler-signed sense of a tracking loop's `λ · carrier_doppler`. A consumer that
+    # forms its own rate residual from a loop's Doppler and compares it with this one
+    # has to negate one of the two; magnitudes agree either way. This matches RTKLIB's
+    # `resdop`, which likewise residuates `-lam * D` against a receding-positive model.
     velocity = SVector{3}(
         velocity_and_drift[1], velocity_and_drift[2], velocity_and_drift[3])
     for j in 1:num_sats
         e = SVector{3}(view(H, j, 1:3))
-        rate_residuals[j] = dot(e, velocity) + velocity_and_drift[4] - rate_residuals[j]
+        rate_residuals[j] -= dot(e, velocity) + velocity_and_drift[4]
     end
     return velocity_and_drift, rate_residuals
 end

--- a/test/pvt.jl
+++ b/test/pvt.jl
@@ -161,14 +161,14 @@ end
     # A satellite not used in the fix returns `nothing` rather than throwing.
     @test get_sat_info(pvt, :GPSL1CA, 999) === nothing
 
-    # Per-satellite post-fit residuals are exposed via SatInfo (modeled − measured
+    # Per-satellite post-fit residuals are exposed via SatInfo (measured − modeled
     # pseudorange, metres); finite and small for a good fix.
     resids = [info.residual for info in values(pvt.sats)]
     @test length(resids) == length(pvt.sats)
     @test all(isfinite, resids)
     @test maximum(abs, resids) < 10m
 
-    # The rate-domain counterpart from the Doppler solve (modeled − measured range
+    # The rate-domain counterpart from the Doppler solve (measured − modeled range
     # rate, m/s): finite, and metre-per-second-level for a stationary receiver.
     rate_resids = [info.rate_residual for info in values(pvt.sats)]
     @test length(rate_resids) == length(pvt.sats)
@@ -428,7 +428,7 @@ end
         @test all(isfinite, rate_residuals)
         # A post-fit least-squares residual is orthogonal to every column of its design
         # — the line-of-sight columns and the common clock-drift column of ones. That is
-        # what makes it a residual rather than an arbitrary modeled-minus-measured
+        # what makes it a residual rather than an arbitrary measured-minus-modeled
         # difference, so it is pinned directly instead of only by magnitude.
         let A = design([[1.0, 0.2, 0.9], [-0.5, 1.0, 0.7], [0.3, -1.0, 0.5], [0.0, 0.1, 1.0]])
             @test norm(A' * rate_residuals) < 1e-6
@@ -481,4 +481,73 @@ end
         @test maximum(abs, [info.residual for info in values(warm.sats)]) ≈
               maximum(abs, [info.residual for info in values(cold.sats)]) rtol = 1e-6
     end
+end
+
+@testset "residuals are observed minus computed" begin
+    # The reported orientation is a convention rather than a by-product: `LsqFit`
+    # residuates `model - data`, and the velocity solve's own measurement `yⱼ` carries
+    # `-doppler * λ`, so either domain would report the opposite sign if left to itself.
+    # Both are pinned here in the sense RTKLIB's `rescode` / `resdop` define — a
+    # measurement exceeding the model reads positive — because a silent flip is
+    # invisible to every magnitude-based assertion elsewhere in this suite.
+
+    # ── Pseudorange ──────────────────────────────────────────────────────────────
+    user = [3.9074e6, 3.0684e5, 5.0150e6]
+    dirs = [[0.3, 0.1, 0.95], [-0.6, 0.3, 0.75], [0.2, -0.8, 0.55],
+        [0.7, 0.5, 0.5], [-0.3, -0.5, 0.8], [0.0, 0.9, 0.45]]
+    sat_positions = reduce(hcat, [user .+ 2.0e7 .* normalize(d) for d in dirs])
+    bias_columns = PositionVelocityTime.BiasColumns(ones(Int, 6), 1, zeros(Int, 6), 0)
+    ρ = PositionVelocityTime.calc_ρ_hat!(
+        zeros(6), sat_positions, [user; 30.0], bias_columns)
+    _, resid = PositionVelocityTime.user_position(sat_positions, ρ, bias_columns)
+    @test maximum(abs, resid) < 1e-6   # self-consistent data ⇒ no residual
+
+    # ±100 m on satellite 3's measurement alone. Least squares spreads part of it over
+    # the four unknowns, so the satellite keeps `1 - P₃₃` of it — a fraction, but with
+    # the sign of the perturbation: measuring long reads positive, short negative. (How
+    # large the fraction is depends on the satellite's leverage, so only the sign and
+    # the bound are pinned.)
+    perturbed(δ) = last(PositionVelocityTime.user_position(
+        sat_positions, (ρ_δ = copy(ρ); ρ_δ[3] += δ; ρ_δ), bias_columns))[3]
+    @test 0.0 < perturbed(100.0) < 100.0
+    @test -100.0 < perturbed(-100.0) < 0.0
+    # Antisymmetric to sub-mm: the model is nonlinear in position, so the two do not
+    # mirror each other exactly.
+    @test perturbed(100.0) ≈ -perturbed(-100.0) atol = 1e-3
+
+    # ── Range rate ───────────────────────────────────────────────────────────────
+    # Reported in `yⱼ`'s geometric sense (positive while the satellite recedes), so a
+    # *higher* measured Doppler — closing faster — reads NEGATIVE. This is the pairing
+    # a receiver forming the same residual from its loops' `λ · carrier_doppler` has to
+    # respect; getting it wrong inverts the field without changing any magnitude.
+    states = gps_l1_states(0.0Hz)[1:5]
+    times = map(PositionVelocityTime.calc_corrected_time, states)
+    sat_pvs = map(
+        (state, time) ->
+            PositionVelocityTime.calc_satellite_position_and_velocity(state.decoder, time),
+        states,
+        times,
+    )
+    # Only H's line-of-sight columns and one column of ones are read, and the sign
+    # result holds for any full-rank design, so a spread-out synthetic one is enough.
+    H = reduce(vcat, [[normalize(d)' 1.0] for d in
+        ([1.0, 0.2, 0.9], [-0.5, 1.0, 0.7], [0.3, -1.0, 0.5], [0.0, 0.1, 1.0],
+            [0.8, -0.3, 0.6])])
+    with_doppler(state, doppler) = PositionVelocityTime.SatelliteState(;
+        decoder = state.decoder,
+        system = state.system,
+        code_phase = state.code_phase,
+        carrier_phase = state.carrier_phase,
+        carrier_doppler = doppler,
+    )
+
+    _, base = PositionVelocityTime.calc_user_velocity_and_clock_drift(
+        sat_pvs, states, times, H)
+    Δdoppler = 50.0Hz
+    faster = copy(states)
+    faster[3] = with_doppler(states[3], states[3].carrier_doppler + Δdoppler)
+    _, closing = PositionVelocityTime.calc_user_velocity_and_clock_drift(
+        sat_pvs, faster, times, H)
+    λ = PositionVelocityTime.SPEEDOFLIGHT / ustrip(Hz, get_center_frequency(states[3].system))
+    @test -λ * ustrip(Hz, Δdoppler) < closing[3] - base[3] < 0.0
 end


### PR DESCRIPTION
## What

`SatInfo.residual` and `SatInfo.rate_residual` change sign. Both are now **measured − modeled**, the orientation GNSS software reports observation residuals in.

Neither sign had been chosen. The pseudorange residual was whatever `LsqFit` hands back (`resid = model - data`), and #67 wrote the range-rate one to match its wording. Self-consistent, but inverted against every reference implementation — and against any receiver that forms the same difference itself.

## Why measured − modeled

| | residual |
|---|---|
| **RTKLIB** `pntpos.c: rescode()` | `v[nv] = P - (r + dtr - CLIGHT*dts + dion + dtrp)`, with `H[j] = -e[j]` |
| **RTKLIB** `pntpos.c: resdop()` | `v[nv] = -lam*obs[i].D[band] - (rate + x[3] - CLIGHT*dts)` |
| **GNSS-SDR** | vendors RTKLIB as `src/algorithms/libs/rtklib/rtklib_pntpos.cc` — both lines verbatim |
| **PocketSDR** | `src/sdr_pvt.c` calls RTKLIB's `pntpos()` and logs `ssat[i].resp[0]`, i.e. that same `v`, as its per-satellite `res` |

Observed minus computed, in both domains, in all three.

## How

The negation is the whole of the change. It is applied to the converged fit and to the solved velocity, so both solves — their iterations, their normal equations, the state they return — are untouched, and `calc_pvt` passes the vectors straight through.

```julia
return ξ_fit_ols.param, -ξ_fit_ols.resid                   # user_position
rate_residuals[j] -= dot(e, velocity) + velocity_and_drift[4]   # velocity solve
```

No API, type or arity change: field access and keyword construction are unaffected, which is why this is a `fix:` and not a `feat!:`.

## One asymmetry survives, and is now documented

`yⱼ` carries `-doppler * λ`, so `rate_residual` runs in the **geometric range-rate sense — positive while the satellite recedes**. That is RTKLIB's `resdop` sense, but the negative of the `λ · carrier_doppler` a tracking loop works in. A consumer forming the rate residual from its own loops has to negate one of the two; magnitudes agree either way.

This is invisible to a magnitude check, so it is stated on `SatInfo` and at the residual loop rather than left to be rediscovered. It is exactly what bit the downstream port below: matching the *wording* of "modeled − measured" there produced numbers inverted against this package's, and only a numerical comparison caught it.

## Tests

Every existing residual assertion in the suite is magnitude- or orthogonality-based, so all of them pass either sign — which is how the inversion went unnoticed in the first place. The new testset pins the orientations directly, in both domains:

- a satellite measured **100 m long** keeps a **positive** residual, one measured short a **negative** one, antisymmetric to sub-mm (the model is nonlinear in position, so not exactly);
- bounded by the perturbation but not pinned to a fraction of it: how much of it the satellite keeps is `1 - Pⱼⱼ`, its leverage;
- a satellite whose Doppler is raised by **50 Hz** — closing faster — moves its rate residual **negative**, by less than `λ · 50 Hz`.

Full suite passes, including the opt-in L125 real-data fix (`PVT_RUN_INTEGRATION_TEST=true`, 8/8).

## Downstream

`GNSSReceiver.jl`'s vector-tracking loop reports the same two fields from its navigation filter and has been aligned in lockstep (its `sc/vector-tracking` branch): pseudorange `z - h(x)`, rate `h(x) - z`, the second because of the observable asymmetry above. Verified numerically against this branch rather than from the docstrings:

```
PVT (measured − modelled) = -1256.374…
VT   h − z                = -1256.374…   ← match
VT   z − h                =  1256.374…
```

Anything else thresholding on the **sign** of `residual` (rather than `abs`) inverts; `rate_residual` is new in 5.0.0 and not yet in General, so it has no released consumers to speak of.

Merges cleanly with #68 and #69 — neither touches these lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
