### PR TITLE
fix: map the tropospheric delay with the Niell mapping functions

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -33,6 +33,8 @@ documented here for reference and for diagnostic use.
 PositionVelocityTime.select_ionospheric_correction
 PositionVelocityTime.ionospheric_delay
 PositionVelocityTime.tropospheric_delay
+PositionVelocityTime.saastamoinen_zenith_delays
+PositionVelocityTime.niell_mapping_functions
 PositionVelocityTime.KlobucharParams
 PositionVelocityTime.NTCMGParams
 PositionVelocityTime._elevation_azimuth

--- a/src/PositionVelocityTime.jl
+++ b/src/PositionVelocityTime.jl
@@ -511,15 +511,16 @@ end
 
 """
     predict_atmospheric_delays(ξ, states, sat_positions, correction,
-                               reference_time, enable_tropospheric_correction) -> Vector{Float64}
+                               reference_time, doy, enable_tropospheric_correction) -> Vector{Float64}
 
 Per-satellite ionospheric + tropospheric delay (metres), to be subtracted from the
 pseudoranges. The user position is the first three elements of the least-squares
 state vector `ξ = [x, y, z, tc₁, …]` (ECEF, metres); the remaining clock-bias
 components are ignored. `correction` is the constellation-wide ionospheric model
 from [`select_ionospheric_correction`](@ref) (`nothing` skips the ionosphere); the
-troposphere uses the blind Saastamoinen model (see [`tropospheric_delay`](@ref))
-unless `enable_tropospheric_correction` is `false`.
+troposphere uses the blind Saastamoinen zenith delays mapped by the Niell mapping
+functions, whose seasonal term takes the day of year `doy` (see
+[`tropospheric_delay`](@ref)), unless `enable_tropospheric_correction` is `false`.
 
 A single corrected solve is enough: the delays depend on position only through the
 satellite elevation/azimuth (and, for the troposphere, the user height), and
@@ -535,6 +536,7 @@ function predict_atmospheric_delays(
     sat_positions,
     correction,
     reference_time,
+    doy,
     enable_tropospheric_correction,
 )
     user_pos = ECEF(ξ[1], ξ[2], ξ[3])
@@ -551,7 +553,8 @@ function predict_atmospheric_delays(
             reference_time,
         )
         tropo =
-            enable_tropospheric_correction ? tropospheric_delay(elevation, user_lla) : 0.0
+            enable_tropospheric_correction ? tropospheric_delay(elevation, user_lla, doy) :
+            0.0
         iono + tropo
     end
 end
@@ -596,7 +599,8 @@ have been decoded, otherwise no correction. See
 [`select_ionospheric_correction`](@ref) and [`ionospheric_delay`](@ref).
 
 Unless disabled via `enable_tropospheric_correction`, the tropospheric delay is
-corrected with the blind Saastamoinen model (no broadcast coefficients needed).
+corrected with a blind model (no broadcast coefficients needed): Saastamoinen
+zenith delays mapped to the line of sight by the Niell mapping functions.
 See [`tropospheric_delay`](@ref).
 
 # Arguments
@@ -697,6 +701,14 @@ function calc_pvt(
     ggto_offsets = calc_ggto_range_offsets(ggto_decoder, systems, times)
     pseudo_ranges = pseudo_ranges .- ggto_offsets
 
+    # The primary system's week and start epoch date the epoch absolutely: the day of
+    # year feeds the tropospheric mapping's seasonal term here, and week/start epoch
+    # date the reported time after the solve.
+    primary_state = healthy_states[findfirst(==(primary_system), systems)]
+    week = get_week(primary_state.decoder; approximate_year)
+    start_time = system_start_epoch(primary_state.system)
+    doy = _day_of_year(primary_state.system, week, reference_time)
+
     # Seed each clock bias from the previous solution, reconstructing a system's
     # absolute bias from the reference bias plus its stored inter-system bias.
     prev_abs_bias(sys) =
@@ -743,7 +755,7 @@ function calc_pvt(
         if correct_atmosphere
             atmospheric_delays = predict_atmospheric_delays(
                 ξ_uncorrected, healthy_states, sat_positions, ionospheric_correction,
-                reference_time, enable_tropospheric_correction)
+                reference_time, doy, enable_tropospheric_correction)
             user_position(
                 sat_positions_mat, pseudo_ranges .- atmospheric_delays, bias_columns, ξ_uncorrected)
         else
@@ -757,7 +769,7 @@ function calc_pvt(
             correct_atmosphere ?
             pseudo_ranges .- predict_atmospheric_delays(
                 prev_ξ, healthy_states, sat_positions, ionospheric_correction,
-                reference_time, enable_tropospheric_correction) : pseudo_ranges
+                reference_time, doy, enable_tropospheric_correction) : pseudo_ranges
         user_position(sat_positions_mat, corrected_ranges, bias_columns, prev_ξ)
     end
     H = calc_H(sat_positions_mat, ξ, bias_columns)
@@ -788,9 +800,6 @@ function calc_pvt(
     # See https://github.com/JuliaGNSS/PositionVelocityTime.jl/issues/8
     corrected_reference_time = reference_time - time_correction / SPEEDOFLIGHT
 
-    primary_state = healthy_states[findfirst(==(primary_system), systems)]
-    week = get_week(primary_state.decoder; approximate_year)
-    start_time = system_start_epoch(primary_state.system)
     # Assumes `start_time.fraction == 0` (true for GPS/Galileo: integer-second origins).
     time = TAIEpoch(
         week * 7 * 24 * 60 * 60 + floor(Int, corrected_reference_time) + start_time.second,

--- a/src/troposphere.jl
+++ b/src/troposphere.jl
@@ -1,89 +1,184 @@
 # ===========================================================================
-#  Tropospheric correction — Saastamoinen model
+#  Tropospheric correction — Saastamoinen zenith delays × Niell mapping functions
 #
 #  The tropospheric delay is non-dispersive — the same on every GNSS frequency.
 #  Unlike the ionosphere there are no broadcast coefficients: the delay is a
-#  "blind" function of the user height and a standard atmosphere, mapped to the
-#  line of sight by the satellite elevation. This is the Saastamoinen model as
-#  implemented in RTKLIB's `tropmodel` (and used by GNSS-SDR / PocketSDR for
-#  single-point positioning), with the relative humidity fixed at 70 % and a
-#  simple 1/cos(z) obliquity mapping.
+#  "blind" function of the user position and a standard atmosphere, mapped to the
+#  line of sight by the satellite elevation. The model has two independent parts:
+#
+#   1. Zenith delays: the Saastamoinen hydrostatic and wet zenith delays driven by
+#      a standard atmosphere, exactly as in RTKLIB's `tropmodel` (which GNSS-SDR
+#      and PocketSDR reuse for single-point positioning), with the relative
+#      humidity defaulting to 70 %.
+#   2. Obliquity mapping: the Niell mapping functions (Niell 1996, as in RTKLIB's
+#      `tropmapf`/`nmf` used for PPP, and Orekit's `NiellMappingFunctionModel`) —
+#      a continued fraction in sin(elevation) with separate hydrostatic and wet
+#      coefficients interpolated over latitude, a seasonal term, and a height
+#      correction. Unlike the flat-slab 1/cos(z) mapping RTKLIB's `tropmodel`
+#      itself uses, it accounts for Earth curvature and ray bending, so it stays
+#      finite at the horizon and does not over-predict at low elevation
+#      (+14 % ≈ +3 m at 5° for 1/cos(z); see #62).
+#
+#  Saastamoinen's own −B·tan²(z) + δR slant correction (carried by Orekit's
+#  `ModifiedSaastamoinenModel`) is deliberately NOT included: it is the 1972
+#  curvature/bending fix *to the 1/cos(z) mapping*, superseded by the mapping
+#  function — adding both would double-count, and the tan² term inverts the sign
+#  of the delay below ≈ 1.9° elevation, forcing Orekit's low-elevation clamp.
+#
+#  Reference: A. E. Niell (1996), "Global mapping functions for the atmosphere
+#  delay at radio wavelengths", J. Geophys. Res. 101(B2), 3227–3246. The original
+#  paper has typos in eqs. (4)–(5); the coefficients below are the corrected
+#  Table 3/4 values, identical in RTKLIB (`rtkcmn.c`) and Orekit.
 # ===========================================================================
 
 const _DEFAULT_RELATIVE_HUMIDITY = 0.7  # GNSS-SDR / RTKLIB default
 
-# Lowest elevation the obliquity mapping is evaluated at. The 1/cos(z) mapping
-# diverges towards the horizon, so a satellite a few tenths of a degree up would be
-# credited a delay of hundreds of metres — enough to drag a least-squares fix off.
-# Below this bound the delay computed *at* the bound is reused, which keeps the
-# correction finite, monotone and continuous across the horizon instead of jumping
-# to zero there.
-#
-# This is a numerical guard, not an estimate: at the bound it yields ≈ 48 m where a
-# curved-atmosphere mapping gives ≈ 37 m, while a genuinely grazing ray is ≈ 90 m.
-# It is defensible only because 1/sin(E) is unusable this low anyway (see #62) and
-# such observations should be masked or de-weighted rather than trusted.
-#
-# The value is taken from Orekit's
-# `ModifiedSaastamoinenModel.DEFAULT_LOW_ELEVATION_THRESHOLD`, but note their bound
-# guards a different failure: Orekit carries Saastamoinen's −B·tan²z curvature term,
-# which goes quadratically negative and inverts the sign of the total delay below
-# E ≈ 1.9°, so 0.05 rad sits just above *that* pathology. Ours has no such term and
-# fails by diverging instead, so the value is borrowed rather than derived — it
-# happens to coincide with the 3° lower validity limit that the mapping-function
-# literature (Niell 1996, VMF3, IERS Conventions ch. 9) settles on.
-const _LOW_ELEVATION_THRESHOLD = 0.05  # rad ≈ 2.87°, caps the mapping at 1/sin ≈ 20
+# Niell hydrostatic coefficients: averages and seasonal amplitudes at latitudes
+# 15°, 30°, 45°, 60°, 75° (linearly interpolated in |latitude|, constant outside).
+# The coefficient at day-of-year `doy` is `average − amplitude·cos(2π(doy−28)/365.25)`,
+# phase-shifted half a year in the southern hemisphere.
+const _NMF_HYDROSTATIC_AVERAGE = (
+    a = (1.2769934e-3, 1.2683230e-3, 1.2465397e-3, 1.2196049e-3, 1.2045996e-3),
+    b = (2.9153695e-3, 2.9152299e-3, 2.9288445e-3, 2.9022565e-3, 2.9024912e-3),
+    c = (62.610505e-3, 62.837393e-3, 63.721774e-3, 63.824265e-3, 64.258455e-3),
+)
+const _NMF_HYDROSTATIC_AMPLITUDE = (
+    a = (0.0, 1.2709626e-5, 2.6523662e-5, 3.4000452e-5, 4.1202191e-5),
+    b = (0.0, 2.1414979e-5, 3.0160779e-5, 7.2562722e-5, 11.723375e-5),
+    c = (0.0, 9.0128400e-5, 4.3497037e-5, 84.795348e-5, 170.37206e-5),
+)
+# Niell wet coefficients: latitude-dependent only — the wet delay's short
+# correlation time makes a seasonal average meaningless (Niell 1996, §4).
+const _NMF_WET = (
+    a = (5.8021897e-4, 5.6794847e-4, 5.8118019e-4, 5.9727542e-4, 6.1641693e-4),
+    b = (1.4275268e-3, 1.5138625e-3, 1.4572752e-3, 1.5007428e-3, 1.7599082e-3),
+    c = (4.3472961e-2, 4.6729510e-2, 4.3908931e-2, 4.4626982e-2, 5.4736038e-2),
+)
+# Height-correction coefficients (Niell 1996 eq. 6): the hydrostatic mapping
+# refers to sea level, and the correction `(1/sin E − m_ht(E)) · height[km]`
+# accounts for the atmosphere column below a raised site.
+const _NMF_HEIGHT = (a = 2.53e-5, b = 5.49e-3, c = 1.14e-3)
 
-"""
-    tropospheric_delay(elevation, lla; humidity = 0.7) -> Float64
+# Lowest elevation the *height-correction term* is evaluated at. Its leading
+# 1/sin(E) is the same flat-slab form the continued fractions replace, so the term
+# diverges at the horizon (and is 0·∞ = NaN there at height 0) even though the
+# mapping functions themselves stay finite; below this bound the term is frozen at
+# its value here. The freeze is harmless — the term is ≈ 7 cm per km of site height
+# at the bound — and the value coincides with the ≈ 3° lower validity limit of the
+# mapping-function literature (Niell 1996, VMF3, IERS Conventions 2010 ch. 9) and
+# with Orekit's `DEFAULT_LOW_ELEVATION_THRESHOLD`.
+const _HEIGHT_CORRECTION_MIN_ELEVATION = 0.05  # rad ≈ 2.87°
 
-Slant tropospheric group delay in metres for a satellite at `elevation` (radians)
-seen from the user geodetic position `lla` (a `Geodesy.LLA`), using the
-Saastamoinen model driven by a standard atmosphere. The delay is non-dispersive
-(frequency independent). `humidity` is the relative humidity (0…1) used for the
-wet component. Elevations below 0.05 rad (≈ 2.87°), including negative ones, are
-treated as 0.05 rad, so the delay saturates near the horizon instead of diverging.
-Returns `0.0` when the user height is outside the model's valid range
-(−100 m … 10 km).
+# Piecewise-linear interpolation of a Niell coefficient over |latitude| in degrees,
+# with nodes at 15°, 30°, 45°, 60°, 75° and held constant outside (RTKLIB `interpc`).
+function _interpolate_nmf_coefficient(values::NTuple{5,Float64}, abs_latitude_deg)
+    x = abs_latitude_deg / 15.0
+    i = floor(Int, x)
+    i < 1 && return values[1]
+    i >= 5 && return values[5]
+    w = x - i
+    return values[i] * (1.0 - w) + values[i+1] * w
+end
 
-The geometry is taken precomputed so a whole-epoch correction shares the user
-geodetic conversion and the elevation with [`ionospheric_delay`](@ref).
-"""
-function tropospheric_delay(elevation, lla; humidity = _DEFAULT_RELATIVE_HUMIDITY)
-    return saastamoinen_delay(deg2rad(lla.lat), lla.alt, elevation, humidity)
+# Normalized Marini continued fraction (Herring normalization): exactly 1 at
+# zenith, finite at the horizon (sin E = 0), strictly decreasing in elevation.
+function _marini_mapping(sin_el, a, b, c)
+    return (1.0 + a / (1.0 + b / (1.0 + c))) /
+           (sin_el + a / (sin_el + b / (sin_el + c)))
 end
 
 """
-    saastamoinen_delay(latitude, height, elevation, humidity) -> Float64
+    niell_mapping_functions(latitude, height, elevation, doy) -> (hydrostatic, wet)
 
-Saastamoinen slant tropospheric delay in metres. `latitude`/`elevation` are in
-radians and `height` is the geodetic (ellipsoidal) height in metres. The standard
-atmosphere (pressure, temperature, water-vapour partial pressure) is derived from
-the height with a 15 °C sea-level temperature, and the hydrostatic and wet zenith
-delays are mapped to the slant direction by `1/cos(z)` with `z = π/2 − elevation`.
-Mirrors RTKLIB's `tropmodel`, except that the elevation is bounded from below by
-`_LOW_ELEVATION_THRESHOLD` (as in Orekit's `ModifiedSaastamoinenModel`): the mapping
-would otherwise grow without bound towards the horizon, so elevations below the
-threshold — including satellites below the horizon — reuse the delay at the
-threshold, roughly 20 × the zenith delay.
-
-The flat-slab `1/cos(z)` mapping over-predicts at low elevation, by ≈ 14 % (≈ 3 m) at
-5° and ≈ 4 % at 10°, since it ignores Earth curvature and ray bending; the bound caps
-the divergence but not that bias. See #62.
+The Niell (1996) hydrostatic and wet mapping functions: dimensionless factors that
+map the zenith tropospheric delays to a satellite at `elevation` (radians).
+`latitude` is in radians, `height` is the site's ellipsoidal height in metres (it
+enters the hydrostatic height correction; RTKLIB likewise substitutes the
+ellipsoidal height for the orthometric one), and `doy` is the day of year driving
+the hydrostatic seasonal term (phase-shifted half a year in the southern
+hemisphere). Elevations below the horizon are evaluated at the horizon, where both
+factors are finite (≈ 37 hydrostatic, ≈ 57 wet); both decrease strictly to exactly
+1 at zenith.
 """
-function saastamoinen_delay(latitude, height, elevation, humidity)
-    (height < -100.0 || height > 1.0e4) && return 0.0
-    hgt = height < 0.0 ? 0.0 : height
+function niell_mapping_functions(latitude, height, elevation, doy)
+    el = max(elevation, 0.0)
+    sin_el = sin(el)
+    abs_lat = abs(rad2deg(latitude))
+    # Seasonal term, southern hemisphere shifted by half a year
+    cosy = cos(2π * ((doy - 28.0) / 365.25 + (latitude < 0.0 ? 0.5 : 0.0)))
+    ah = _interpolate_nmf_coefficient(_NMF_HYDROSTATIC_AVERAGE.a, abs_lat) -
+         _interpolate_nmf_coefficient(_NMF_HYDROSTATIC_AMPLITUDE.a, abs_lat) * cosy
+    bh = _interpolate_nmf_coefficient(_NMF_HYDROSTATIC_AVERAGE.b, abs_lat) -
+         _interpolate_nmf_coefficient(_NMF_HYDROSTATIC_AMPLITUDE.b, abs_lat) * cosy
+    ch = _interpolate_nmf_coefficient(_NMF_HYDROSTATIC_AVERAGE.c, abs_lat) -
+         _interpolate_nmf_coefficient(_NMF_HYDROSTATIC_AMPLITUDE.c, abs_lat) * cosy
+    aw = _interpolate_nmf_coefficient(_NMF_WET.a, abs_lat)
+    bw = _interpolate_nmf_coefficient(_NMF_WET.b, abs_lat)
+    cw = _interpolate_nmf_coefficient(_NMF_WET.c, abs_lat)
+    el_ht = max(el, _HEIGHT_CORRECTION_MIN_ELEVATION)
+    dm =
+        (1.0 / sin(el_ht) -
+         _marini_mapping(sin(el_ht), _NMF_HEIGHT.a, _NMF_HEIGHT.b, _NMF_HEIGHT.c)) *
+        height / 1.0e3
+    hydrostatic = _marini_mapping(sin_el, ah, bh, ch) + dm
+    wet = _marini_mapping(sin_el, aw, bw, cw)
+    return hydrostatic, wet
+end
+
+"""
+    saastamoinen_zenith_delays(latitude, height, humidity) -> (hydrostatic, wet)
+
+Saastamoinen zenith hydrostatic and wet tropospheric delays in metres, from a
+standard atmosphere (15 °C at sea level) evaluated at the geodetic `latitude`
+(radians) and `height` (metres, clamped below at 0). `humidity` is the relative
+humidity (0…1) feeding the water-vapour partial pressure of the wet term. The
+formulas are those of RTKLIB's `tropmodel` at zenith.
+"""
+function saastamoinen_zenith_delays(latitude, height, humidity)
+    hgt = max(height, 0.0)
     # Standard atmosphere
     pressure = 1013.25 * (1.0 - 2.2557e-5 * hgt)^5.2568          # hPa
     temperature = 15.0 - 6.5e-3 * hgt + 273.16                  # K (15 °C at sea level)
     e = 6.108 * humidity * exp((17.15 * temperature - 4684.0) / (temperature - 38.45))  # hPa
-    # Saastamoinen hydrostatic and wet slant delays (1/cos(z) obliquity mapping),
-    # with the elevation bounded from below so the mapping cannot diverge
-    z = π / 2 - max(elevation, _LOW_ELEVATION_THRESHOLD)
-    trph =
+    hydrostatic =
         0.0022768 * pressure /
-        (1.0 - 0.00266 * cos(2.0 * latitude) - 0.00028 * hgt / 1.0e3) / cos(z)
-    trpw = 0.002277 * (1255.0 / temperature + 0.05) * e / cos(z)
-    return trph + trpw
+        (1.0 - 0.00266 * cos(2.0 * latitude) - 0.00028 * hgt / 1.0e3)
+    wet = 0.002277 * (1255.0 / temperature + 0.05) * e
+    return hydrostatic, wet
+end
+
+"""
+    tropospheric_delay(elevation, lla, doy; humidity = 0.7) -> Float64
+
+Slant tropospheric group delay in metres for a satellite at `elevation` (radians)
+seen from the user geodetic position `lla` (a `Geodesy.LLA`): the Saastamoinen
+zenith delays (see [`saastamoinen_zenith_delays`](@ref)) mapped to the line of
+sight by the Niell mapping functions (see [`niell_mapping_functions`](@ref)),
+whose seasonal term is driven by the day of year `doy`. The delay is
+non-dispersive (frequency independent). `humidity` is the relative humidity (0…1)
+used for the wet component. The delay is finite and monotone in elevation all the
+way down to the horizon (≈ 90 m for a grazing ray at sea level); elevations below
+the horizon reuse the horizon value. Returns `0.0` when the user height is outside
+the model's valid range (−100 m … 10 km).
+
+The geometry is taken precomputed so a whole-epoch correction shares the user
+geodetic conversion and the elevation with [`ionospheric_delay`](@ref).
+"""
+function tropospheric_delay(elevation, lla, doy; humidity = _DEFAULT_RELATIVE_HUMIDITY)
+    (lla.alt < -100.0 || lla.alt > 1.0e4) && return 0.0
+    latitude = deg2rad(lla.lat)
+    height = max(lla.alt, 0.0)
+    zenith_hydrostatic, zenith_wet = saastamoinen_zenith_delays(latitude, height, humidity)
+    hydrostatic_mapping, wet_mapping =
+        niell_mapping_functions(latitude, height, elevation, doy)
+    return zenith_hydrostatic * hydrostatic_mapping + zenith_wet * wet_mapping
+end
+
+# Day of year (1–366) of the GNSS system time given by the absolute `week` and
+# `time_of_week` [s] of `system`. The system time scale's offset from UTC (leap
+# seconds, ≤ ~18 s) is negligible for a seasonal argument with a one-year period.
+function _day_of_year(system, week, time_of_week)
+    epoch = get_system_start_time(system)
+    t = epoch + Millisecond(round(Int, (week * 604800 + time_of_week) * 1000))
+    return dayofyear(t)
 end

--- a/test/pvt_iono_tropo.jl
+++ b/test/pvt_iono_tropo.jl
@@ -907,8 +907,12 @@ const IONO_TROPO_GROUND_TRUTH = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 550.0))
         @test PositionVelocityTime.select_ionospheric_correction(states) isa
               PositionVelocityTime.NTCMGParams
 
+        # The fixture observables were generated with the flat-slab 1/sin(el)
+        # tropospheric mapping baked in, so a solve using the Niell mapping (#62)
+        # reproduces the fixture's truth only up to the mapping difference at these
+        # elevations (~0.5 m here) — a fixture-consistency floor, not solver error.
         pvt = calc_pvt(states; approximate_year = 2020)
-        @test norm(pvt.position - IONO_TROPO_GROUND_TRUTH) < 0.5
+        @test norm(pvt.position - IONO_TROPO_GROUND_TRUTH) < 0.7
 
         uncorrected = calc_pvt(
             states;

--- a/test/troposphere.jl
+++ b/test/troposphere.jl
@@ -1,81 +1,222 @@
-# Independent reimplementation of the Saastamoinen model (RTKLIB `tropmodel`),
-# written with sin(elevation) instead of cos(z) and explicit intermediate terms,
-# to cross-check the package's `saastamoinen_delay`.
-function saastamoinen_reference(lat, height, elevation, humidity)
+# Independent reimplementation of the tropospheric model — Saastamoinen zenith
+# delays (RTKLIB `tropmodel` at zenith) mapped by the Niell (1996) mapping
+# functions (RTKLIB `tropmapf`/`nmf`) — to cross-check the package implementation.
+# Written differently on purpose: latitudes in degrees, table rows as vectors with
+# `searchsortedlast` interpolation, and the seasonal term as a phase shift.
+
+const NMF_LATITUDE_NODES = 15.0:15.0:75.0
+
+# Niell (1996) tables 3 and 4 (corrected paper), rows (a, b, c) per column latitude
+const NMF_HYDROSTATIC_AVG = (
+    [1.2769934e-3, 1.2683230e-3, 1.2465397e-3, 1.2196049e-3, 1.2045996e-3],
+    [2.9153695e-3, 2.9152299e-3, 2.9288445e-3, 2.9022565e-3, 2.9024912e-3],
+    [62.610505e-3, 62.837393e-3, 63.721774e-3, 63.824265e-3, 64.258455e-3],
+)
+const NMF_HYDROSTATIC_AMP = (
+    [0.0, 1.2709626e-5, 2.6523662e-5, 3.4000452e-5, 4.1202191e-5],
+    [0.0, 2.1414979e-5, 3.0160779e-5, 7.2562722e-5, 11.723375e-5],
+    [0.0, 9.0128400e-5, 4.3497037e-5, 84.795348e-5, 170.37206e-5],
+)
+const NMF_WET_REF = (
+    [5.8021897e-4, 5.6794847e-4, 5.8118019e-4, 5.9727542e-4, 6.1641693e-4],
+    [1.4275268e-3, 1.5138625e-3, 1.4572752e-3, 1.5007428e-3, 1.7599082e-3],
+    [4.3472961e-2, 4.6729510e-2, 4.3908931e-2, 4.4626982e-2, 5.4736038e-2],
+)
+const NMF_HEIGHT_REF = (2.53e-5, 5.49e-3, 1.14e-3)
+
+function nmf_interpolate(row, abs_lat_deg)
+    abs_lat_deg <= first(NMF_LATITUDE_NODES) && return first(row)
+    abs_lat_deg >= last(NMF_LATITUDE_NODES) && return last(row)
+    i = searchsortedlast(NMF_LATITUDE_NODES, abs_lat_deg)
+    f = (abs_lat_deg - NMF_LATITUDE_NODES[i]) / step(NMF_LATITUDE_NODES)
+    return (1 - f) * row[i] + f * row[i+1]
+end
+
+# Normalized continued fraction: 1 at zenith, finite at the horizon
+function continued_fraction(sinel, (a, b, c))
+    return (1 + a / (1 + b / (1 + c))) / (sinel + a / (sinel + b / (sinel + c)))
+end
+
+function niell_reference(lat_deg, height, elevation, doy)
+    el = max(elevation, 0.0)
+    # Seasonal phase: day-of-year cosine anchored at doy 28, southern hemisphere
+    # shifted half a year (expressed here as a phase offset of π)
+    phase = 2π * (doy - 28) / 365.25 + (lat_deg < 0 ? π : 0.0)
+    alat = abs(lat_deg)
+    hydrostatic_abc = ntuple(3) do i
+        nmf_interpolate(NMF_HYDROSTATIC_AVG[i], alat) -
+        nmf_interpolate(NMF_HYDROSTATIC_AMP[i], alat) * cos(phase)
+    end
+    wet_abc = ntuple(i -> nmf_interpolate(NMF_WET_REF[i], alat), 3)
+    # Height correction, frozen below 0.05 rad where its 1/sin(el) diverges
+    el_ht = max(el, 0.05)
+    dm = (1 / sin(el_ht) - continued_fraction(sin(el_ht), NMF_HEIGHT_REF)) * height / 1000
+    mh = continued_fraction(sin(el), hydrostatic_abc) + dm
+    mw = continued_fraction(sin(el), wet_abc)
+    return mh, mw
+end
+
+function slant_delay_reference(lat_deg, height, elevation, humidity, doy)
     (height < -100.0 || height > 1.0e4) && return 0.0
     h = max(height, 0.0)
     P = 1013.25 * (1 - 2.2557e-5 * h)^5.2568
     T = 288.16 - 6.5e-3 * h
     e = 6.108 * humidity * exp((17.15 * T - 4684.0) / (T - 38.45))
-    el = max(elevation, 0.05)                         # Orekit's low elevation bound
-    mapping = 1 / sin(el)                             # = 1/cos(z), z = π/2 - el
-    zhd = 0.0022768 * P / (1 - 0.00266 * cos(2lat) - 0.00028 * h / 1000)
+    zhd = 0.0022768 * P / (1 - 0.00266 * cosd(2 * lat_deg) - 0.00028 * h / 1000)
     zwd = 0.002277 * (1255.0 / T + 0.05) * e
-    return (zhd + zwd) * mapping
+    mh, mw = niell_reference(lat_deg, h, elevation, doy)
+    return zhd * mh + zwd * mw
 end
 
-@testset "Saastamoinen tropospheric model" begin
+@testset "Tropospheric model (Saastamoinen zenith × Niell mapping)" begin
     @testset "matches independent reference" begin
-        for lat in deg2rad.((0.0, 48.0, -67.0)),
+        for lat in (0.0, 48.0, -67.0, 80.0),
             h in (0.0, 550.0, 3000.0, 9000.0),
-            el in deg2rad.((-10.0, 0.0, 1.0, 5.0, 15.0, 45.0, 90.0)),
-            humi in (0.0, 0.5, 0.7, 1.0)
+            el in deg2rad.((-10.0, 0.0, 1.0, 3.0, 5.0, 15.0, 45.0, 90.0)),
+            humi in (0.0, 0.7, 1.0),
+            doy in (1, 28, 119, 211, 365)
 
-            got = PositionVelocityTime.saastamoinen_delay(lat, h, el, humi)
-            ref = saastamoinen_reference(lat, h, el, humi)
+            got = PositionVelocityTime.tropospheric_delay(
+                el,
+                LLA(lat, 11.0, h),
+                doy;
+                humidity = humi,
+            )
+            ref = slant_delay_reference(lat, h, el, humi, doy)
             @test got ≈ ref rtol = 1e-12
+
+            mh, mw = PositionVelocityTime.niell_mapping_functions(
+                deg2rad(lat),
+                max(h, 0.0),
+                el,
+                doy,
+            )
+            mh_ref, mw_ref = niell_reference(lat, max(h, 0.0), el, doy)
+            @test mh ≈ mh_ref rtol = 1e-12
+            @test mw ≈ mw_ref rtol = 1e-12
         end
     end
 
-    @testset "physical behaviour" begin
-        lat, humi = deg2rad(48.0), 0.7
-        zenith = PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(90.0), humi)
-        # Zenith total delay at sea level is a couple of metres
-        @test 2.2 < zenith < 2.6
-        # Obliquity: lower elevation → larger slant delay (≈ 1/sin(el))
-        d30 = PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(30.0), humi)
-        d10 = PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(10.0), humi)
-        @test d30 > zenith
-        @test d10 > d30
-        @test d30 ≈ zenith / sin(deg2rad(30.0)) rtol = 1e-12
+    @testset "zenith delay unchanged (regression)" begin
+        lat, humi = 48.0, 0.7
+        # Both mapping functions are exactly 1 at zenith (normalized continued
+        # fraction) and the height correction vanishes there, so the zenith slant
+        # delay is exactly the sum of the zenith delays — as before the remap.
+        mh, mw = PositionVelocityTime.niell_mapping_functions(
+            deg2rad(lat),
+            550.0,
+            π / 2,
+            100,
+        )
+        @test mh ≈ 1.0 rtol = 1e-12
+        @test mw ≈ 1.0 rtol = 1e-12
+        zhd, zwd = PositionVelocityTime.saastamoinen_zenith_delays(deg2rad(lat), 0.0, humi)
+        ztd = PositionVelocityTime.tropospheric_delay(π / 2, LLA(lat, 11.0, 0.0), 100)
+        @test ztd ≈ zhd + zwd rtol = 1e-12
+        # Standard atmosphere at sea level, 70 % RH: ZHD ≈ 2.31 m, ZWD ≈ 0.12 m (#62)
+        @test ztd ≈ 2.43 atol = 0.05
+        @test 2.2 < ztd < 2.6
         # Delay decreases with user height (thinner atmosphere above)
-        @test PositionVelocityTime.saastamoinen_delay(lat, 3000.0, deg2rad(90.0), humi) <
-              zenith
+        @test PositionVelocityTime.tropospheric_delay(π / 2, LLA(lat, 11.0, 3000.0), 100) <
+              ztd
         # Wet component grows with humidity; dry-only is the floor
-        @test PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(90.0), 1.0) >
-              PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(90.0), 0.0)
+        @test PositionVelocityTime.tropospheric_delay(
+            π / 2,
+            LLA(lat, 11.0, 0.0),
+            100;
+            humidity = 1.0,
+        ) > PositionVelocityTime.tropospheric_delay(
+            π / 2,
+            LLA(lat, 11.0, 0.0),
+            100;
+            humidity = 0.0,
+        )
     end
 
-    @testset "low elevations are bounded" begin
-        lat, humi = deg2rad(48.0), 0.7
-        bound = PositionVelocityTime._LOW_ELEVATION_THRESHOLD
-        @test bound == 0.05  # Orekit's DEFAULT_LOW_ELEVATION_THRESHOLD
-        at_bound = PositionVelocityTime.saastamoinen_delay(lat, 0.0, bound, humi)
-        # Everything at or below the bound — grazing, at the horizon, below it — reuses
-        # the delay computed at the bound, so the correction stays finite and continuous
-        # across the horizon instead of diverging or dropping to zero.
-        for el in (bound, 1e-3, 0.0, deg2rad(-5.0), -π / 2)
-            @test PositionVelocityTime.saastamoinen_delay(lat, 0.0, el, humi) == at_bound
+    @testset "low-elevation values match the Niell-mapped references of #62" begin
+        # Issue #62's comparison table: lat 48°, sea level, 70 % RH, average (no
+        # seasonal) coefficients — the doy is chosen so the seasonal cosine is ≈ 0.
+        lla = LLA(48.0, 11.0, 0.0)
+        doy = 119  # 28 + 365.25/4 → cos ≈ 0
+        for (el_deg, mh_expected, slant_expected) in (
+            (15.0, 3.79, 9.2),
+            (10.0, 5.54, 13.5),
+            (5.0, 10.09, 24.6),
+            (3.0, 14.54, 35.5),
+            (0.0, 36.46, 90.9),
+        )
+            mh, _ = PositionVelocityTime.niell_mapping_functions(
+                deg2rad(48.0),
+                0.0,
+                deg2rad(el_deg),
+                doy,
+            )
+            @test mh ≈ mh_expected rtol = 0.03
+            slant = PositionVelocityTime.tropospheric_delay(deg2rad(el_deg), lla, doy)
+            @test slant ≈ slant_expected rtol = 0.03
         end
-        # The cap is just the 1/sin(el) mapping evaluated at the bound — ≈ 20 × zenith,
-        # a few tens of metres instead of the hundreds an unbounded mapping gives. It is
-        # a bound, not an accurate low-elevation delay (see #62).
-        zenith = PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(90.0), humi)
-        @test at_bound ≈ zenith / sin(bound) rtol = 1e-12
-        @test at_bound < 50.0
-        # Above the bound the model is untouched and still monotonic in elevation
-        just_above = PositionVelocityTime.saastamoinen_delay(lat, 0.0, 0.06, humi)
-        @test just_above < at_bound
-        @test PositionVelocityTime.saastamoinen_delay(lat, 0.0, deg2rad(5.0), humi) <
-              just_above
+        # The flat-slab 1/sin(el) mapping the Niell functions replaced over-predicted
+        # by ≈ 14 % at 5° — make sure that bias is gone, not just reduced.
+        ztd = PositionVelocityTime.tropospheric_delay(π / 2, lla, doy)
+        flat_slab_5deg = ztd / sind(5.0)
+        niell_5deg = PositionVelocityTime.tropospheric_delay(deg2rad(5.0), lla, doy)
+        @test niell_5deg < 0.90 * flat_slab_5deg
+    end
+
+    @testset "finite and monotone down to the horizon" begin
+        for h in (0.0, 550.0, 3000.0)
+            lla = LLA(48.0, 11.0, h)
+            delays = map(range(0.0, π / 2; length = 200)) do el
+                PositionVelocityTime.tropospheric_delay(el, lla, 100)
+            end
+            @test all(isfinite, delays)
+            # Strictly decreasing in elevation, no clamp needed above the horizon
+            @test all(diff(delays) .< 0)
+            # A grazing ray at sea level is ≈ 90 m — large, but finite and physical,
+            # unlike the diverging 1/sin(el) mapping (#62)
+            @test delays[1] < 120.0
+            # Below the horizon the horizon value is reused: continuous, finite
+            at_horizon = delays[1]
+            for el in (-1e-6, -0.05, deg2rad(-10.0), -π / 2)
+                @test PositionVelocityTime.tropospheric_delay(el, lla, 100) == at_horizon
+            end
+        end
+    end
+
+    @testset "seasonal term and hemispheres" begin
+        el = deg2rad(5.0)
+        # The hydrostatic coefficients swing over the year at mid/high latitude...
+        mh_winter, mw_winter =
+            PositionVelocityTime.niell_mapping_functions(deg2rad(48.0), 0.0, el, 28)
+        mh_summer, mw_summer =
+            PositionVelocityTime.niell_mapping_functions(deg2rad(48.0), 0.0, el, 211)
+        @test mh_winter != mh_summer
+        # ...the wet coefficients are latitude-only (Niell 1996)
+        @test mw_winter == mw_summer
+        # Southern hemisphere is the northern one shifted half a year
+        mh_south, _ =
+            PositionVelocityTime.niell_mapping_functions(deg2rad(-48.0), 0.0, el, 28)
+        @test mh_south ≈ mh_summer rtol = 1e-6
+        # At the equator seasons cancel out of the tables (amplitude column is
+        # constant below 15°): no day-of-year dependence at all
+        mh_eq_1, _ = PositionVelocityTime.niell_mapping_functions(0.0, 0.0, el, 28)
+        mh_eq_2, _ = PositionVelocityTime.niell_mapping_functions(0.0, 0.0, el, 211)
+        @test mh_eq_1 == mh_eq_2
     end
 
     @testset "out-of-range heights return zero" begin
-        lat, humi = deg2rad(48.0), 0.7
         # User height outside the model's valid range (−100 m … 10 km) returns exactly
         # zero: too high, then too low.
-        @test PositionVelocityTime.saastamoinen_delay(lat, 1.5e4, deg2rad(45.0), humi) == 0.0
-        @test PositionVelocityTime.saastamoinen_delay(lat, -200.0, deg2rad(45.0), humi) == 0.0
+        @test PositionVelocityTime.tropospheric_delay(
+            deg2rad(45.0),
+            LLA(48.0, 11.0, 1.5e4),
+            100,
+        ) == 0.0
+        @test PositionVelocityTime.tropospheric_delay(
+            deg2rad(45.0),
+            LLA(48.0, 11.0, -200.0),
+            100,
+        ) == 0.0
     end
 
     @testset "tropospheric_delay from line-of-sight geometry" begin
@@ -84,12 +225,21 @@ end
         # Satellite roughly overhead → near-zenith, small slant delay (~2 m)
         sat_up = ECEFfromLLA(wgs84)(LLA(48.0, 11.0, 2.0e7))
         el_up, _ = PositionVelocityTime._elevation_azimuth(ENUfromECEF(user, wgs84), sat_up)
-        d_up = PositionVelocityTime.tropospheric_delay(el_up, lla)
+        d_up = PositionVelocityTime.tropospheric_delay(el_up, lla, 100)
         @test 2.0 < d_up < 2.6
         # A low-elevation satellite has a larger slant delay than the near-zenith one
         sat_low = ECEF(user[1] + 2.0e7, user[2] + 2.0e6, user[3] + 2.0e6)
         el_low, _ = PositionVelocityTime._elevation_azimuth(ENUfromECEF(user, wgs84), sat_low)
-        @test PositionVelocityTime.tropospheric_delay(el_low, lla) > d_up
+        @test PositionVelocityTime.tropospheric_delay(el_low, lla, 100) > d_up
         # Frequency independence is implicit: tropospheric_delay takes no system/freq.
+    end
+
+    @testset "day of year from system week and time of week" begin
+        # GPS week 0 starts 1980-01-06 → doy 6; half a year of weeks later lands
+        # mid-year. The ≤ 18 s GPS−UTC offset is irrelevant at day resolution.
+        @test PositionVelocityTime._day_of_year(GPST(), 0, 0.0) == 6
+        @test PositionVelocityTime._day_of_year(GPST(), 0, 86400.0 * 10) == 16
+        # GST week 0 starts 1999-08-21 23:59:47 UTC (doy 233)
+        @test PositionVelocityTime._day_of_year(GST(), 0, 14.0) == 234
     end
 end


### PR DESCRIPTION
Closes #62.

## What

Replaces the flat-slab `1/sin(el)` obliquity mapping of the tropospheric model with the **Niell (1996) mapping functions** (NMF): separate hydrostatic and wet continued fractions in `sin(el)`, coefficients linearly interpolated over |latitude| (nodes at 15°…75°), the seasonal day-of-year term (phase-shifted half a year in the southern hemisphere), and the height correction. The Saastamoinen zenith delays are unchanged; `troposphere.jl` is now structured as `saastamoinen_zenith_delays × niell_mapping_functions`, the standard separation in the literature and in Orekit.

The day of year driving the seasonal term is derived from the primary system's week and time of week, so the model stays fully blind (no external data, no new dependency).

## Why

The flat-slab mapping ignores Earth curvature and ray bending: it over-predicts the slant delay by ≈ +4 % at 10° and ≈ +14 % (**≈ +3 m**) at 5° elevation, and diverges at the horizon — an elevation-dependent systematic that tilts the vertical component (no elevation mask is applied in this package). The Niell mapping is finite and strictly monotone down to elevation 0 on its own (≈ 91 m for a grazing ray, matching the issue's reference), so the former 0.05 rad clamp survives only inside the centimetric height-correction term, whose leading `1/sin(el)` is the one remaining flat-slab form.

Saastamoinen's own `−B·tan²z + δR` slant correction (Orekit's `ModifiedSaastamoinenModel`) is deliberately **not** added: it is the 1972 curvature fix to the `1/cos(z)` mapping that a proper mapping function supersedes (adding both would double-count), and it inverts the delay's sign below ≈ 1.9° elevation, which is what forces Orekit's low-elevation clamp.

## Correctness

- Coefficients are the corrected Niell Table 3/4 values (the original JGR paper has typos in eqs. 4–5), verified digit-for-digit against two independent implementations: RTKLIB's `tropmapf`/`nmf` (used there for PPP; RTKLIB/GNSS-SDR/PocketSDR use the flat-slab `tropmodel` only for SPP) and Orekit's `NiellMappingFunctionModel`.
- `test/troposphere.jl` is rewritten against an independent NMF reimplementation (5810 assertions) and covers the issue's acceptance criteria: slant delay within 3 % of the #62 reference values for 0°–15°, finite/monotone to the horizon without a clamp, zenith delay exactly unchanged (the normalized continued fraction is exactly 1 at zenith).
- The Galileo e2e fixture tolerance widens 0.5 → 0.7 m: those hardcoded observables were generated with the flat-slab delay baked in, so the mapping difference at their elevations is a fixture-consistency floor, not solver error.

## Performance

Per-satellite evaluation 26 → 44 ns, still zero-allocation (coefficient tables are `NTuple` constants); `calc_pvt` warm-start ≈ +1 µs (~4 %) with an identical allocation profile (648 allocs / 23.3 KiB), measured on the repo's GPS benchmark fixture.

## Out of scope

The issue's steps 2 and 3 (elevation-dependent weighting `σ² = a² + b²/sin²E` and an optional `elmin` mask) touch the solver rather than the troposphere model and are left for a follow-up, as the issue itself suggests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)