### PR TITLE
feat: support Tracking 7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ LinearAlgebra = "1"
 LsqFit = "0.12, 0.13, 0.14, 0.15, 0.16"
 StaticArrays = "1"
 Test = "1"
-Tracking = "3, 4, 5, 6"
+Tracking = "3, 4, 5, 6, 7"
 Unitful = "1"
 julia = "1.10"
 


### PR DESCRIPTION
Adds `7` to the `Tracking` compat bound, now that [Tracking 7.0.0](https://github.com/JuliaGNSS/Tracking.jl/pull/223) is registered.

## Why it is needed

`Tracking` is a **weak** dependency here, so this bound constrains every environment that resolves PositionVelocityTime — not just this package's own tests. GNSSReceiver is one of them, and until this is released it cannot move to Tracking 7 at all:

```
ERROR: Unsatisfiable requirements detected for package Tracking [10b2438b]:
 └─restricted by compatibility requirements with PositionVelocityTime [52ec0b5e] to versions: uninstalled
```

This PR is therefore the gate on the GNSSReceiver bump.

## Why no code change is needed

Tracking 7 replaces the NWPR C/N₀ estimator with a measured per-signal noise reference and makes it the default. Everything it breaks sits on `TrackState` (a new `noise_estimators` type parameter and a scratch field) and on `CN0UpdateContext`. The extension here is built on the `TrackedSat` accessors `get_code_phase`, `get_carrier_doppler` and `get_carrier_phase`, which are untouched, and `SatelliteState` reads no C/N₀.

## Verification

Full suite run against the merged Tracking PR tree with its version set to `7.0.0`: green, including the `Tracking extension: SatelliteState from a Tracking sat state` testset and Aqua. The opt-in L125 integration test (`PVT_RUN_INTEGRATION_TEST`) was not run locally; it builds its state through the keyword `TrackState(; signals = ...)` form, which defaults the new field, and drives the sample-driven `track!`, which fills the noise reference itself.

Kept as an added entry (`3, 4, 5, 6, 7`) rather than a bump: nothing here needs Tracking 7 over 3–6, so narrowing the bound would only make downstream resolution harder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Commit type:** `feat:` rather than `build:` — a compat bound only reaches consumers once it is registered, so this needs to cut a release.
