### PR TITLE
feat: support Tracking 8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ LinearAlgebra = "1"
 LsqFit = "0.12, 0.13, 0.14, 0.15, 0.16"
 StaticArrays = "1"
 Test = "1"
-Tracking = "3, 4, 5, 6, 7"
+Tracking = "3, 4, 5, 6, 7, 8"
 Unitful = "1"
 julia = "1.10"
 


### PR DESCRIPTION
Adds `8` to the `Tracking` compat bound, ahead of [Tracking 8.0.0](https://github.com/JuliaGNSS/Tracking.jl/pull/229) appearing in the General registry (merged, registration pending).

## Why it is needed

`Tracking` is a **weak** dependency here, so this bound constrains every environment that resolves PositionVelocityTime — not just this package's own tests. GNSSReceiver is one of them, and until this is released it cannot move to Tracking 8 at all:

```
ERROR: Unsatisfiable requirements detected for package Tracking [10b2438b]:
 └─restricted by compatibility requirements with PositionVelocityTime [52ec0b5e] to versions: uninstalled
```

This PR is therefore the gate on the GNSSReceiver bump.

## Why no code change is needed

Tracking 8 measures an antenna array's noise as a spatial covariance instead of on one fixed antenna column, so a beamformed prompt is divided by the floor its own combiner sees. Everything it breaks sits on the combining side: `AbstractPostCorrFilter` stops being a callable and declares its weights through the new `get_weights`, `get_default_post_corr_filter` is removed, and `CorrelatorNoiseEstimator` gains a `num_ants` its signal group has to agree with.

The extension here is built on the `TrackedSat` accessors `get_code_phase`, `get_carrier_doppler` and `get_carrier_phase`, which are untouched; `SatelliteState` reads no C/N₀, and nothing here constructs a post-correlation filter or a noise estimator.

## Verification

Full suite run against the merged Tracking tree at version `8.0.0`: green, including the `Tracking extension: SatelliteState from a Tracking sat state` testset and Aqua. The opt-in L125 integration test (`PVT_RUN_INTEGRATION_TEST`) was not run locally; it builds its state through the keyword `TrackState(; signals = ...)` form, which provisions the noise estimators for the group's antenna count itself, and drives the sample-driven `track!`, which fills them.

Kept as an added entry (`3, 4, 5, 6, 7, 8`) rather than a bump: nothing here needs Tracking 8 over 3–7, so narrowing the bound would only make downstream resolution harder.

CI resolves Tracking 7 until 8.0.0 is registered, so this is green either side of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Commit type:** `feat:` rather than `build:` — a compat bound only reaches consumers once it is registered, so this needs to cut a release.
